### PR TITLE
Initial test commit for proxy AMQP

### DIFF
--- a/metactical/custom_scripts/utils/rabbitmq_handler.py
+++ b/metactical/custom_scripts/utils/rabbitmq_handler.py
@@ -1,0 +1,68 @@
+import frappe
+import pika
+import json
+
+def publish_to_rabbitmq(server_ip, exchange, exchange_type, routing_key, message, username, password, queue_name):
+    try:
+        credentials = pika.PlainCredentials(username, password)
+        parameters = pika.ConnectionParameters(host=server_ip, credentials=credentials)
+        connection = pika.BlockingConnection(parameters)
+        channel = connection.channel()
+        
+        # Declare a persistent topic exchange
+        channel.exchange_declare(exchange=exchange, exchange_type=exchange_type, durable=True)
+        frappe.logger().info(f"Exchange declared: {exchange} (type: {exchange_type})")
+        
+        # Declare a durable queue
+        channel.queue_declare(queue=queue_name, durable=True)
+        frappe.logger().info(f"Queue declared: {queue_name}")
+        
+        # Bind the queue to the exchange with the given routing key
+        channel.queue_bind(exchange=exchange, queue=queue_name, routing_key=routing_key)
+        frappe.logger().info(f"Queue bound to exchange: {queue_name} -> {exchange} (routing key: {routing_key})")
+        
+        # Publish the message
+        channel.basic_publish(
+            exchange=exchange,
+            routing_key=routing_key,
+            body=message,
+            properties=pika.BasicProperties(
+                delivery_mode=2,  # Make message persistent
+            ))
+        frappe.logger().info(f"Message published to exchange: {exchange} (routing key: {routing_key})")
+        
+        connection.close()
+    except Exception as e:
+        frappe.logger().error(f"Error publishing message: {str(e)}")
+        raise e
+
+@frappe.whitelist(allow_guest=True)
+def webhook():
+    data = frappe.request.get_json()
+
+    # Check for missing required fields
+    required_fields = ['server_ip', 'exchange', 'exchange_type', 'routing_key', 'queue_name', 'username', 'password', 'message']
+    missing_fields = [field for field in required_fields if field not in data]
+
+    if missing_fields:
+        error_message = f"Missing required fields: {', '.join(missing_fields)}"
+        frappe.logger().error(error_message)
+        frappe.throw(error_message)
+
+    # Extract RabbitMQ configuration from the incoming request
+    server_ip = data['server_ip']
+    exchange = data['exchange']
+    exchange_type = data['exchange_type']
+    routing_key = data['routing_key']
+    queue_name = data['queue_name']
+    username = data['username']
+    password = data['password']
+    message = data['message']
+
+    # Log received data for debugging
+    frappe.logger().info(f"Received data: {data}")
+
+    # Publish to RabbitMQ
+    publish_to_rabbitmq(server_ip, exchange, exchange_type, routing_key, message, username, password, queue_name)
+
+    return {'status': 'Message published to RabbitMQ'}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 frappe
 python-barcode
 xmltodict
+pika


### PR DESCRIPTION
This is a proxy endpoint to be used by ERP Webhooks and creates a request to AMQP 0-9-1 protocol integration 
right now all parameters are needed to send the information including host / authentication information of RabbitMQ 
any keys after the password will be used as part of the message to AMQP to be published 

the final version will have an authentication key and will verify origin 

sample request body for the end point 
{
  "server_ip": "ec2-54-89-240-111.compute-1.amazonaws.com",
  "exchange": "variant.pricelist.publish",
  "exchange_type": "topic",
  "routing_key": "variant.pricelist.update",
  "queue_name": "variant_pricelist_queue_canada",
  "message": "Hello, RabbitMQ!",
  "username": "guest",
  "password": "guest",
  
  "message_type" : "price_change",
  "variant_sku" : "1111",
  "price" : "11.2",
  "currency" : "CAD"
}

requires pika to be installed on the server - added to requirements.txt