### PR TITLE
End of day report v4 master

### DIFF
--- a/metactical/api/end_of_day_report.py
+++ b/metactical/api/end_of_day_report.py
@@ -2,7 +2,7 @@ import frappe
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_us_report_data(date):
 	#date = "2023-02-16"
 	data = []

--- a/metactical/api/end_of_day_report.py
+++ b/metactical/api/end_of_day_report.py
@@ -29,7 +29,7 @@ def get_us_report_data(date):
 					FROM
 						`tabSales Invoice`
 					WHERE
-						source = %(source)s AND posting_date = %(date)s
+						source = %(source)s AND neb_payment_completed_at = %(date)s
 						AND docstatus = 1"""
 			query = frappe.db.sql(sql, {"source": source.name, "date": date}, as_dict=1)
 			if len(query) > 0:
@@ -51,7 +51,7 @@ def get_us_report_data(date):
 									FROM
 										`tabSales Invoice`
 									WHERE
-										source = %(source)s AND posting_date BETWEEN %(start_date)s
+										source = %(source)s AND neb_payment_completed_at BETWEEN %(start_date)s
 										AND %(end_date)s AND docstatus = 1""",
 								{"source": source.name, "start_date": start_date, "end_date": date}, as_dict=1)
 			if len(query) > 0:
@@ -71,9 +71,9 @@ def get_us_report_data(date):
 			query = frappe.db.sql("""SELECT
 										COALESCE(SUM(total), 0) AS total_pmtd
 									FROM
-										`tabSales Order`
+										`tabSales Invoice`
 									WHERE
-										source = %(source)s AND transaction_date BETWEEN %(start_date)s
+										source = %(source)s AND neb_payment_completed_at BETWEEN %(start_date)s
 										AND %(end_date)s AND docstatus = 1""", 
 								{"source": source.name, "start_date": start_date, "end_date": end_date}, as_dict=1)
 			if len(query) > 0:
@@ -101,7 +101,7 @@ def get_us_report_data(date):
 					FROM
 						`tabSales Order`
 					WHERE
-						source = %(source)s AND transaction_date = %(date)s
+						source = %(source)s AND neb_payment_completed_at = %(date)s
 						AND docstatus = 1"""
 			query = frappe.db.sql(sql, {"source": source.name, "date": date}, as_dict=1)
 			if len(query) > 0:
@@ -122,7 +122,7 @@ def get_us_report_data(date):
 									FROM
 										`tabSales Order`
 									WHERE
-										source = %(source)s AND transaction_date BETWEEN %(start_date)s
+										source = %(source)s AND neb_payment_completed_at BETWEEN %(start_date)s
 										AND %(end_date)s AND docstatus = 1""",
 								{"source": source.name, "start_date": start_date, "end_date": date}, as_dict=1)
 			if len(query) > 0:
@@ -144,7 +144,7 @@ def get_us_report_data(date):
 									FROM
 										`tabSales Order`
 									WHERE
-										source = %(source)s AND transaction_date BETWEEN %(start_date)s
+										source = %(source)s AND neb_payment_completed_at BETWEEN %(start_date)s
 										AND %(end_date)s AND docstatus = 1""", 
 								{"source": source.name, "start_date": start_date, "end_date": end_date}, as_dict=1)
 			if len(query) > 0:

--- a/metactical/custom_scripts/auto_email_report/auto_email_report.py
+++ b/metactical/custom_scripts/auto_email_report/auto_email_report.py
@@ -22,7 +22,7 @@ class CustomAutoEmailReport(AutoEmailReport):
 			return frappe.render_template(
 				"frappe/templates/emails/auto_email_report.html",
 				{
-					"title": self.name + " (" + formatted_date + ")",
+					"title": self.name + " Franchise (" + formatted_date + ")",
 					"description": self.description,
 					"date_time": date_time,
 					"columns": columns,

--- a/metactical/metactical/doctype/item_search_settings/item_search_settings.json
+++ b/metactical/metactical/doctype/item_search_settings/item_search_settings.json
@@ -13,6 +13,19 @@
   "api_key",
   "api_secret",
   "section_warehouses",
+  "rameen_instance_credentials_section",
+  "rameen_daily_report_url",
+  "rameen_sales_report_url",
+  "column_break_4g42q",
+  "rameen_api_key",
+  "rameen_api_secret",
+  "qc1_instance_credentials_section",
+  "qc1_daily_report_url",
+  "qc1_sales_report_url",
+  "column_break_3h7of",
+  "qc1_api_key",
+  "qc1_api_secret",
+  "section_break_svddt",
   "warehouses",
   "section_price_list",
   "print_price_list",
@@ -84,11 +97,73 @@
    "fieldname": "franchise_settings",
    "fieldtype": "Table",
    "options": "Item Search Settings Franchise"
+  },
+  {
+   "fieldname": "rameen_instance_credentials_section",
+   "fieldtype": "Section Break",
+   "label": "Rameen Instance Credentials"
+  },
+  {
+   "fieldname": "rameen_daily_report_url",
+   "fieldtype": "Data",
+   "label": "Daily Report URL"
+  },
+  {
+   "fieldname": "rameen_sales_report_url",
+   "fieldtype": "Data",
+   "label": "Sales Report URL"
+  },
+  {
+   "fieldname": "column_break_4g42q",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "rameen_api_key",
+   "fieldtype": "Data",
+   "label": "API Key"
+  },
+  {
+   "fieldname": "rameen_api_secret",
+   "fieldtype": "Password",
+   "label": "API Secret"
+  },
+  {
+   "fieldname": "qc1_instance_credentials_section",
+   "fieldtype": "Section Break",
+   "label": "QC1 Instance Credentials"
+  },
+  {
+   "fieldname": "qc1_daily_report_url",
+   "fieldtype": "Data",
+   "label": "Daily Report URL"
+  },
+  {
+   "fieldname": "qc1_sales_report_url",
+   "fieldtype": "Data",
+   "label": "Sales Report URL"
+  },
+  {
+   "fieldname": "column_break_3h7of",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "qc1_api_key",
+   "fieldtype": "Data",
+   "label": "API Key"
+  },
+  {
+   "fieldname": "qc1_api_secret",
+   "fieldtype": "Password",
+   "label": "API Secret"
+  },
+  {
+   "fieldname": "section_break_svddt",
+   "fieldtype": "Section Break"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-06-30 06:08:21.173973",
+ "modified": "2024-08-13 16:54:10.864373",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Item Search Settings",

--- a/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
+++ b/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
@@ -220,9 +220,10 @@ def get_website_stores_data(filters, location):
 
 def get_us_data(item_search_settings, filters):
 	us_data = []
+	
 	if item_search_settings.get("daily_report_url") is not None and item_search_settings.get("daily_report_url") != "":
 		us_request = requests.get(item_search_settings.get("daily_report_url"), 
-						auth=(item_search_settings.api_key, item_search_settings.api_secret),
+						auth=(item_search_settings.api_key, item_search_settings.get_password("api_secret")),
 									params={"date": filters.get("date")})
 
 		if us_request.status_code == 200:
@@ -244,7 +245,7 @@ def get_rameen_data(item_search_settings,  filters):
 	rameen_data = []
 	if item_search_settings.get("rameen_daily_report_url") is not None and item_search_settings.get("rameen_daily_report_url") != "":
 		us_request = requests.get(item_search_settings.get("rameen_daily_report_url"), 
-						auth=(item_search_settings.rameen_api_key, item_search_settings.rameen_api_secret),
+						auth=(item_search_settings.rameen_api_key, item_search_settings.get_password("rameen_api_secret")),
 									params={"date": filters.get("date")})
 
 		if us_request.status_code == 200:
@@ -265,8 +266,9 @@ def get_qc1_data(item_search_settings, filters):
 	qc1_data = []
 	if item_search_settings.get("qc1_daily_report_url") is not None and item_search_settings.get("qc1_daily_report_url") != "":
 		us_request = requests.get(item_search_settings.get("qc1_daily_report_url"), 
-						auth=(item_search_settings.qc1_api_key, item_search_settings.qc1_api_secret),
+						auth=(item_search_settings.qc1_api_key, item_search_settings.get_password("qc1_api_secret")),
 									params={"date": filters.get("date")})
+									
 		if us_request.status_code == 200:
 			for row in us_request.json().get("message", {}):
 				qc1_data.append(row)

--- a/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
+++ b/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
@@ -268,7 +268,7 @@ def get_qc1_data(item_search_settings, filters):
 		us_request = requests.get(item_search_settings.get("qc1_daily_report_url"), 
 						auth=(item_search_settings.qc1_api_key, item_search_settings.get_password("qc1_api_secret")),
 									params={"date": filters.get("date")})
-									
+
 		if us_request.status_code == 200:
 			for row in us_request.json().get("message", {}):
 				qc1_data.append(row)
@@ -298,7 +298,7 @@ def export_to_excel(date):
 		'filters': dates
 	}
 
-	sub_headers = ["Stores", "Online", "USA"]
+	sub_headers = ["Stores", "Online", "USA", "QC1", "Rameen"]
 	export_query(data, sub_headers)
 
 	

--- a/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
+++ b/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
@@ -220,7 +220,6 @@ def get_website_stores_data(filters, location):
 
 def get_us_data(item_search_settings, filters):
 	us_data = []
-	print(filters.get("date"))
 	if item_search_settings.get("daily_report_url") is not None and item_search_settings.get("daily_report_url") != "":
 		us_request = requests.get(item_search_settings.get("daily_report_url"), 
 						auth=(item_search_settings.api_key, item_search_settings.api_secret),

--- a/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
+++ b/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
@@ -9,13 +9,29 @@ from dateutil.relativedelta import relativedelta
 def execute(filters=None):
 	columns, data = [], []
 	columns = get_columns(filters)
-	
+	item_search_settings = frappe.get_doc("Item Search Settings")
+
 	# Get Canada and US data
 	data = get_ca_data(filters)
-	us_data = get_us_data(filters)
+
+	# Get USA data
+	us_data = get_us_data(item_search_settings, filters)
+
 	if len(us_data) > 0:
 		data.append({"Location": "USA"})
 		data.extend(us_data)
+
+	# Get Rameen data
+	rameen_data = get_rameen_data(item_search_settings, filters)
+	if len(rameen_data) > 0:
+		data.append({"Location": "Rameen"})
+		data.extend(rameen_data)
+
+	# Get QC1 data
+	qc1_data = get_qc1_data(item_search_settings, filters)
+	if len(qc1_data) > 0:
+		data.append({"Location": "QC1"})
+		data.extend(qc1_data)
 		
 	return columns, data
 	
@@ -183,7 +199,7 @@ def get_website_stores_data(filters, location):
 			query = frappe.db.sql("""SELECT
 										COALESCE(SUM(total), 0) AS total_pmtd
 									FROM
-										`tabSales Order`
+										`""" + doctype + """`
 									WHERE
 										source = %(source)s AND neb_payment_completed_at BETWEEN %(start_date)s
 										AND %(end_date)s AND docstatus = 1""", 
@@ -202,13 +218,14 @@ def get_website_stores_data(filters, location):
 			data.append(row)
 	return data, total_with_tax, total_without_tax, total_mtd, total_pmtd 
 
-def get_us_data(filters):
-	item_search_settings = frappe.get_doc("Item Search Settings")
+def get_us_data(item_search_settings, filters):
 	us_data = []
+	print(filters.get("date"))
 	if item_search_settings.get("daily_report_url") is not None and item_search_settings.get("daily_report_url") != "":
 		us_request = requests.get(item_search_settings.get("daily_report_url"), 
 						auth=(item_search_settings.api_key, item_search_settings.api_secret),
 									params={"date": filters.get("date")})
+
 		if us_request.status_code == 200:
 			for row in us_request.json().get("message", {}):
 				us_data.append(row)
@@ -222,6 +239,48 @@ def get_us_data(filters):
 			row.update({"location": "Total - USD"})
 
 	return us_data
+
+def get_rameen_data(item_search_settings,  filters):
+	item_search_settings = frappe.get_doc("Item Search Settings")
+	rameen_data = []
+	if item_search_settings.get("rameen_daily_report_url") is not None and item_search_settings.get("rameen_daily_report_url") != "":
+		us_request = requests.get(item_search_settings.get("rameen_daily_report_url"), 
+						auth=(item_search_settings.rameen_api_key, item_search_settings.rameen_api_secret),
+									params={"date": filters.get("date")})
+
+		if us_request.status_code == 200:
+			for row in us_request.json().get("message", {}):
+				rameen_data.append(row)
+
+	for row in rameen_data:
+		if row.get("location") == "Total Stores":
+			row.update({"location": "Stores Total"})
+		elif row.get("location") == "Total Websites":
+			row.update({"location": "Websites Total"})
+		elif row.get("location") == "USD Total":
+			row.update({"location": "Total - USD"})
+	
+	return rameen_data
+
+def get_qc1_data(item_search_settings, filters):
+	qc1_data = []
+	if item_search_settings.get("qc1_daily_report_url") is not None and item_search_settings.get("qc1_daily_report_url") != "":
+		us_request = requests.get(item_search_settings.get("qc1_daily_report_url"), 
+						auth=(item_search_settings.qc1_api_key, item_search_settings.qc1_api_secret),
+									params={"date": filters.get("date")})
+		if us_request.status_code == 200:
+			for row in us_request.json().get("message", {}):
+				qc1_data.append(row)
+
+	for row in qc1_data:
+		if row.get("location") == "Total Stores":
+			row.update({"location": "Stores Total"})
+		elif row.get("location") == "Total Websites":
+			row.update({"location": "Websites Total"})
+		elif row.get("location") == "USD Total":
+			row.update({"location": "Total - USD"})
+	
+	return qc1_data
 
 @frappe.whitelist()
 def export_to_excel(date):


### PR DESCRIPTION
1. QC1 and Rameen daily report data is included in the report
2. New fields added to Item Search Settings to hold the link & API credentials for daily sales report of qc1 and rameen.
3. Removed `allow_guests=True` flag from end_of_day_report API endpoint
4. Updated the title of the report to "End of Day Report - V4 Franchise (date here)"