### PR TITLE
End of day report - v4 franchise

### DIFF
--- a/metactical/custom_scripts/auto_email_report/auto_email_report.py
+++ b/metactical/custom_scripts/auto_email_report/auto_email_report.py
@@ -13,7 +13,7 @@ import datetime
 
 class CustomAutoEmailReport(AutoEmailReport):
 	def get_html_table(self, columns=None, data=None):
-		if self.report == "End of Day Report - V4":
+		if self.report == "End of Day Report - V4" or self.report == "End of Day Report - V4 Franchise":
 			date_time = global_date_format(now()) + " " + format_time(now())
 			report_doctype = frappe.db.get_value("Report", self.report, "ref_doctype")
 
@@ -22,7 +22,7 @@ class CustomAutoEmailReport(AutoEmailReport):
 			return frappe.render_template(
 				"frappe/templates/emails/auto_email_report.html",
 				{
-					"title": self.name + " Franchise (" + formatted_date + ")",
+					"title": self.name + " (" + formatted_date + ")",
 					"description": self.description,
 					"date_time": date_time,
 					"columns": columns,

--- a/metactical/metactical/doctype/item_search_settings/item_search_settings.json
+++ b/metactical/metactical/doctype/item_search_settings/item_search_settings.json
@@ -13,18 +13,6 @@
   "api_key",
   "api_secret",
   "section_warehouses",
-  "rameen_instance_credentials_section",
-  "rameen_daily_report_url",
-  "rameen_sales_report_url",
-  "column_break_4g42q",
-  "rameen_api_key",
-  "rameen_api_secret",
-  "qc1_instance_credentials_section",
-  "qc1_daily_report_url",
-  "qc1_sales_report_url",
-  "column_break_3h7of",
-  "qc1_api_key",
-  "qc1_api_secret",
   "section_break_svddt",
   "warehouses",
   "section_price_list",
@@ -99,71 +87,13 @@
    "options": "Item Search Settings Franchise"
   },
   {
-   "fieldname": "rameen_instance_credentials_section",
-   "fieldtype": "Section Break",
-   "label": "Rameen Instance Credentials"
-  },
-  {
-   "fieldname": "rameen_daily_report_url",
-   "fieldtype": "Data",
-   "label": "Daily Report URL"
-  },
-  {
-   "fieldname": "rameen_sales_report_url",
-   "fieldtype": "Data",
-   "label": "Sales Report URL"
-  },
-  {
-   "fieldname": "column_break_4g42q",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "rameen_api_key",
-   "fieldtype": "Data",
-   "label": "API Key"
-  },
-  {
-   "fieldname": "rameen_api_secret",
-   "fieldtype": "Password",
-   "label": "API Secret"
-  },
-  {
-   "fieldname": "qc1_instance_credentials_section",
-   "fieldtype": "Section Break",
-   "label": "QC1 Instance Credentials"
-  },
-  {
-   "fieldname": "qc1_daily_report_url",
-   "fieldtype": "Data",
-   "label": "Daily Report URL"
-  },
-  {
-   "fieldname": "qc1_sales_report_url",
-   "fieldtype": "Data",
-   "label": "Sales Report URL"
-  },
-  {
-   "fieldname": "column_break_3h7of",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "qc1_api_key",
-   "fieldtype": "Data",
-   "label": "API Key"
-  },
-  {
-   "fieldname": "qc1_api_secret",
-   "fieldtype": "Password",
-   "label": "API Secret"
-  },
-  {
    "fieldname": "section_break_svddt",
    "fieldtype": "Section Break"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-08-13 16:54:10.864373",
+ "modified": "2024-08-19 15:10:15.427702",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Item Search Settings",

--- a/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
+++ b/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
@@ -21,17 +21,19 @@ def execute(filters=None):
 		data.append({"Location": "USA"})
 		data.extend(us_data)
 
-	# Get Rameen data
-	rameen_data = get_rameen_data(item_search_settings, filters)
-	if len(rameen_data) > 0:
-		data.append({"Location": "Rameen"})
-		data.extend(rameen_data)
+	###### ------ New report (End of Day Report - v4 Franchise) created for qc1 and rameen data ------ ###### 
+	
+	# # Get Rameen data
+	# rameen_data = get_rameen_data(item_search_settings, filters)
+	# if len(rameen_data) > 0:
+	# 	data.append({"Location": "Rameen"})
+	# 	data.extend(rameen_data)
 
-	# Get QC1 data
-	qc1_data = get_qc1_data(item_search_settings, filters)
-	if len(qc1_data) > 0:
-		data.append({"Location": "QC1"})
-		data.extend(qc1_data)
+	# # Get QC1 data
+	# qc1_data = get_qc1_data(item_search_settings, filters)
+	# if len(qc1_data) > 0:
+	# 	data.append({"Location": "QC1"})
+	# 	data.extend(qc1_data)
 		
 	return columns, data
 	

--- a/metactical/metactical/report/end_of_day_report___v4_franchise/end_of_day_report___v4_franchise.js
+++ b/metactical/metactical/report/end_of_day_report___v4_franchise/end_of_day_report___v4_franchise.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2023, Techlift Technologies and contributors
+// For license information, please see license.txt
+/* eslint-disable */
+
+var tday = new Date().toISOString().split('T')[0];
+frappe.query_reports["End of Day Report - V4 Franchise"] = {
+	"filters": [
+		{
+			"fieldname": "date",
+			"fieldtype": "Date",
+			"label": "Date",
+			"reqd": 1,
+			default: tday
+		},
+		{
+			"fieldname": "end_date",
+			"fieldtype": "Date",
+			"label": "End Date",
+			"reqd": 1,
+			default: tday,
+			"hidden": 1
+        }
+	],
+	onload: function(report) {
+		report.page.add_inner_button(__("Export to Excel"), function() {
+			var filters = report.get_values();
+			var date = filters.date;
+			var url = frappe.urllib.get_full_url(
+				"/api/method/metactical.metactical.report.end_of_day_report___v4_franchise.end_of_day_report___v4_franchise.export_to_excel?"
+				+ "date=" + encodeURIComponent(date)
+			);
+			window.open(url);
+		});
+	}
+};

--- a/metactical/metactical/report/end_of_day_report___v4_franchise/end_of_day_report___v4_franchise.json
+++ b/metactical/metactical/report/end_of_day_report___v4_franchise/end_of_day_report___v4_franchise.json
@@ -1,0 +1,30 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2024-08-19 13:49:08.597293",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "",
+ "modified": "2024-08-19 13:49:08.597293",
+ "modified_by": "Administrator",
+ "module": "Metactical",
+ "name": "End of Day Report - V4 Franchise",
+ "owner": "Administrator",
+ "prepared_report": 1,
+ "ref_doctype": "Sales Invoice",
+ "report_name": "End of Day Report - V4 Franchise",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Accounts Manager"
+  },
+  {
+   "role": "Accounts User"
+  }
+ ]
+}

--- a/metactical/metactical/report/end_of_day_report___v4_franchise/end_of_day_report___v4_franchise.py
+++ b/metactical/metactical/report/end_of_day_report___v4_franchise/end_of_day_report___v4_franchise.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2023, Techlift Technologies and contributors
+# For license information, please see license.txt
+
+import frappe
+import requests
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+def execute(filters=None):
+	columns, data = [], []
+	columns = get_columns(filters)
+	item_search_settings = frappe.get_doc("Item Search Settings")
+
+	# Get Rameen data
+	rameen_data = get_rameen_data(item_search_settings, filters)
+	if len(rameen_data) > 0:
+		# data.append({"Location": "Rameen"})
+		data.extend(rameen_data)
+
+	# Get QC1 data
+	qc1_data = get_qc1_data(item_search_settings, filters)
+	if len(qc1_data) > 0:
+		data.append({"Location": "QC1"})
+		data.extend(qc1_data)
+		
+	return columns, data
+	
+def get_columns(filters):
+	columns = [
+		{
+			"fieldname": "location",
+			"fieldtype": "Location",
+			"label": "Location",
+			"options": "Lead Source",
+			"width": 200
+		},
+		{
+			"fieldname": "total_without_tax",
+			"fieldtype": "Currency",
+			"label": "Total Without Tax",
+			"width": 140
+		},
+		{
+			"fieldname": "space",
+			"fieldtype": "Data",
+			"label": "",
+			"width": 100
+		},
+		{
+			"fieldname": "total_mtd",
+			"fieldtype": "Currency",
+			"label": "CMA Sales",
+			"width": 120
+		},
+		{
+			"fieldname": "total_pmtd",
+			"fieldtype": "Currency",
+			"label": "PYMA Sales",
+			"width": 120
+		}
+	]
+	return columns
+
+def get_rameen_data(item_search_settings,  filters):
+	item_search_settings = frappe.get_doc("Item Search Settings")
+	rameen_data = []
+	if item_search_settings.get("rameen_daily_report_url") is not None and item_search_settings.get("rameen_daily_report_url") != "":
+		us_request = requests.get(item_search_settings.get("rameen_daily_report_url"), 
+						auth=(item_search_settings.rameen_api_key, item_search_settings.get_password("rameen_api_secret")),
+									params={"date": filters.get("date")})
+
+		if us_request.status_code == 200:
+			for row in us_request.json().get("message", {}):
+				rameen_data.append(row)
+
+	for row in rameen_data:
+		if row.get("location") == "Total Stores":
+			row.update({"location": "Stores Total"})
+		elif row.get("location") == "Total Websites":
+			row.update({"location": "Websites Total"})
+		elif row.get("location") == "USD Total":
+			row.update({"location": "Total - USD"})
+	
+	return rameen_data
+
+def get_qc1_data(item_search_settings, filters):
+	qc1_data = []
+	if item_search_settings.get("qc1_daily_report_url") is not None and item_search_settings.get("qc1_daily_report_url") != "":
+		us_request = requests.get(item_search_settings.get("qc1_daily_report_url"), 
+						auth=(item_search_settings.qc1_api_key, item_search_settings.get_password("qc1_api_secret")),
+									params={"date": filters.get("date")})
+
+		if us_request.status_code == 200:
+			for row in us_request.json().get("message", {}):
+				qc1_data.append(row)
+
+	for row in qc1_data:
+		if row.get("location") == "Total Stores":
+			row.update({"location": "Stores Total"})
+		elif row.get("location") == "Total Websites":
+			row.update({"location": "Websites Total"})
+		elif row.get("location") == "USD Total":
+			row.update({"location": "Total - USD"})
+	
+	return qc1_data
+
+@frappe.whitelist()
+def export_to_excel(date):
+	from metactical.custom_scripts.utils.metactical_utils import export_query
+
+	dates = {
+		"date": date,
+		"end_date": (datetime.strptime(date, "%Y-%m-%d") + relativedelta(days=1)).strftime("%Y-%m-%d")
+	}
+
+	data = {
+		'report_name': 'End of Day Report - V4 Franchise', 
+		'file_format_type': 'Excel', 
+		'filters': dates
+	}
+
+	sub_headers = ["QC1", "Rameen"]
+	export_query(data, sub_headers)
+
+	

--- a/metactical/metactical/workspace/metactical/metactical.json
+++ b/metactical/metactical/workspace/metactical/metactical.json
@@ -347,8 +347,26 @@
   {
    "hidden": 0,
    "is_query_report": 0,
+   "label": "Item Import Tool",
+   "link_to": "Item From Excel",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
    "label": " Purchase Order Import Tool",
    "link_to": "Purchase Order Import Tool",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Pricing Rule Import Tool",
+   "link_to": "Pricing Rule From Excel",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -534,6 +552,15 @@
   {
    "hidden": 0,
    "is_query_report": 1,
+   "label": "End Of Day Report - V4 Franchise",
+   "link_to": "End of Day Report - V4 Franchise",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
    "label": "Sales Register",
    "link_to": "Metactical Sales Register",
    "link_type": "Report",
@@ -617,6 +644,15 @@
    "is_query_report": 1,
    "label": "Store Credits",
    "link_to": "Store Credits",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Pricing Rule Report - V1",
+   "link_to": "Pricing Rule Report - V1",
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
@@ -828,7 +864,7 @@
    "type": "Link"
   }
  ],
- "modified": "2024-07-22 08:55:37.534107",
+ "modified": "2024-08-19 15:02:47.276366",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Metactical",


### PR DESCRIPTION
1. A new report "End of Day Report - V4 Franchise" is added. It'll fetch the daily sales report from qc1 and rameen and display the information in the main ERP.

2. Removed the fields that are added to store URL and API credentials for QC1 and Rameen since there is a table "Franchise Settings" which holds exactly same information.

3. Because franchise instances are separated from the main report, title of the "Auto Email Report" is updated from "End of Day Report - v4 Franchise" to "End of Day Report - v4"

4. Removed QC1 and Rameen instances from the existing v4 report and moved to the new report