### PR TITLE
removed restriction and add a warning message for items with qty > qoh

### DIFF
--- a/metactical/custom_scripts/material_request/material_request.js
+++ b/metactical/custom_scripts/material_request/material_request.js
@@ -70,15 +70,6 @@ frappe.ui.form.on('Material Request', {
 });
 
 frappe.ui.form.on('Material Request Item', {
-	qty: function(frm, cdt, cdn) {
-		var row = locals[cdt][cdn];
-		if (row.qty > row.qoh) {
-			frappe.msgprint(__("Quantity cannot be greater than Quantity on Hand"));
-			row.qty = row.qoh;
-			frm.refresh_field('items');
-		}
-	},
-
 	item_code: function(frm, cdt, cdn) {
 		get_qoh(frm, cdt, cdn)
 	},
@@ -105,6 +96,9 @@ var get_quantities_on_hand = function(frm) {
 }
 
 var get_qoh = function(frm, cdt=null, cdn=null, rows=null) {
+	if (frm.doc.material_request_type != "Material Transfer")
+		return
+
 	if (!rows){
 		var row = locals[cdt][cdn];
 		if (!row.item_code || !row.from_warehouse) {
@@ -118,7 +112,6 @@ var get_qoh = function(frm, cdt=null, cdn=null, rows=null) {
 			}]
 		}
 	}
-
 
 	frappe.call({
 		method: "metactical.custom_scripts.material_request.material_request.get_qoh",

--- a/metactical/custom_scripts/material_request/material_request.py
+++ b/metactical/custom_scripts/material_request/material_request.py
@@ -16,10 +16,18 @@ def before_save(self, method):
 					suppliers += item.ais_default_supplier
 		self.ais_suppliers = suppliers
 
+def on_submit(self, method):
 	# check if a qty greater than the quantity on hand is entered
-	for item in self.items:
-		if item.qty > item.qoh:
-			frappe.throw("Quantity entered for item <b>{0}</b> is greater than the available quantity (<b>{1}</b>) in the warehouse".format(item.item_code, item.qoh))
+	if self.material_request_type == "Material Transfer":
+		items = []
+		for item in self.items:
+			if item.qty > item.qoh:
+				items.append(item.item_code) 
+
+		if items:
+			message = 'The quantities of these items exceed the available warehouse stock. <br>'
+			message += "<b>" + ', '.join(items) + "</b>"
+			frappe.msgprint(message)
 
 def set_default_supplier(self):
 	for item in self.items:

--- a/metactical/hooks.py
+++ b/metactical/hooks.py
@@ -115,7 +115,8 @@ doc_events = {
 		"validate": "metactical.barcode_generator.po_validate",
 	},
 	"Material Request": {
-		"before_save": "metactical.custom_scripts.material_request.material_request.before_save"
+		"before_save": "metactical.custom_scripts.material_request.material_request.before_save",
+		"on_submit": "metactical.custom_scripts.material_request.material_request.on_submit",
 	},
 	"Address": {
 		"validate": "metactical.custom_scripts.address.address.validate"


### PR DESCRIPTION
1. removed the front-end restriction for adding a quantity more than the actual stock in the warehouse
2. changed the validation in the backend to restrict creation of MRs with more quantity of items than the actual stock to a warning message after submission
3. updated to check only MRs for material transafer