### PR TITLE
check for permission when users creating a tag from a document

### DIFF
--- a/metactical/custom_scripts/tag/tag.py
+++ b/metactical/custom_scripts/tag/tag.py
@@ -1,0 +1,20 @@
+import frappe
+from frappe.desk.doctype.tag.tag import DocTags
+
+@frappe.whitelist()
+def add_tag(tag, dt, dn, color=None):
+    # check if user has permission to add tags to this document
+    if not frappe.has_permission("Tag Link", "create"):
+        frappe.throw("Insufficient permission to add tags to this document")
+    else:
+        DocTags(dt).add(dn, tag)
+        return tag
+
+@frappe.whitelist()
+def remove_tag(tag, dt, dn):
+    # check if user has permission to remove tags from this document
+    if not frappe.has_permission("Tag Link", "delete"):
+        frappe.throw("Insufficient permission to remove tags from this document")
+    else:
+        DocTags(dt).remove(dn, tag)
+        return tag

--- a/metactical/custom_scripts/tag/tag.py
+++ b/metactical/custom_scripts/tag/tag.py
@@ -4,7 +4,9 @@ from frappe.desk.doctype.tag.tag import DocTags
 @frappe.whitelist()
 def add_tag(tag, dt, dn, color=None):
     # check if user has permission to add tags to this document
-    if not frappe.has_permission("Tag Link", "create"):
+    if not frappe.has_permission("Tag", "create") and not frappe.db.exists("Tag", tag):
+        frappe.throw("Insufficient permission to create Tag")
+    elif not frappe.has_permission("Tag Link", "create"):
         frappe.throw("Insufficient permission to add tags to this document")
     else:
         DocTags(dt).add(dn, tag)

--- a/metactical/hooks.py
+++ b/metactical/hooks.py
@@ -205,7 +205,9 @@ override_whitelisted_methods = {
 	"erpnext.stock.get_item_details.get_item_details": "metactical.custom_scripts.get_item_details.get_item_details",
 	"erpnext.selling.doctype.sales_order.sales_order.make_sales_invoice": "metactical.custom_scripts.sales_order.sales_order.make_sales_invoice",
 	"erpnext.stock.doctype.pick_list.pick_list.PickList.set_item_locations": "metactical.custom_scripts.pick_list.pick_list.CustomPickList.set_item_locations",
-	"erpnext.setup.utils.get_exchange_rate": "metactical.custom_scripts.setup.utils.get_exchange_rate"
+	"erpnext.setup.utils.get_exchange_rate": "metactical.custom_scripts.setup.utils.get_exchange_rate",
+	"frappe.desk.doctype.tag.tag.add_tag": "metactical.custom_scripts.tag.tag.add_tag",
+	"frappe.desk.doctype.tag.tag.remove_tag": "metactical.custom_scripts.tag.tag.remove_tag"
 }
 #
 # each overriding function accepts a `data` argument;


### PR DESCRIPTION
Restricted users without "Create" permission for Tag from creating or deleting a tag inside documents.