### PR TITLE
restricted the  number of items in the cycle count to be less than 100

### DIFF
--- a/metactical/metactical/doctype/cycle_count/cycle_count.py
+++ b/metactical/metactical/doctype/cycle_count/cycle_count.py
@@ -22,10 +22,14 @@ class CycleCount(Document):
 					"qty": row.qty,
 					"valuation_rate": row.valuation_rate
 				})
+		
 		if hasattr(doc, "items"):
 			doc.submit()
 
 	def validate(self):
+		if len(self.items) > 99:
+			frappe.throw("You can't add more than 99 items in a Cycle Count")
+
 		for row in self.items:
 			if row.get("expected_qty") is None:
 				expected = get_expected_qty(row.item_code, self.warehouse)


### PR DESCRIPTION
Fix for https://tree.taiga.io/project/mariamr-dev-work-aisenyi/us/850

limited the number of items in the Cycle Count to fewer than 100. This restriction was added because an error occurs when submitting a Stock Reconciliation generated from a Cycle Count with more than 100 items.