### PR TITLE
convert the api secret before sending to the api for the reports

### DIFF
--- a/metactical/metactical/report/detailed_sales_report_v1/detailed_sales_report_v1.py
+++ b/metactical/metactical/report/detailed_sales_report_v1/detailed_sales_report_v1.py
@@ -36,6 +36,8 @@ def execute(filters=None):
 
 		row["ifw_retailskusuffix"] = i.get("ifw_retailskusuffix")
 		row["item_name"] = i.get("item_name")
+		item_groups = get_item_group_parents(i.get("item_group"))
+		row["itemgroups"] = item_groups
 		row["item_code"] = i.get("item_code")
 
 		row["ifw_duty_rate"] = i.get("ifw_duty_rate")
@@ -390,6 +392,12 @@ def get_column(filters,conditions):
 				"fieldname": "item_name",
 				"fieldtype": "Data",
 				"width": 300,
+			},
+			{
+				"label": "ItemGroups",
+				"fieldname": "itemgroups",
+				"fieldtype": "Data",
+				"width": 200
 			},
 			{
 				"label": _("ItemImage"),
@@ -870,7 +878,7 @@ def get_master(conditions="", filters={}):
 				ifw_po_notes, ais_poreorderqty, ais_poreorderlevel, 
 				s.ifw_supplier_qoh, i.stock_uom, i.purchase_uom, i.lead_time_days,
 				i.min_order_qty, i.safety_stock, i.variant_of, i.ais_poreorderqty,
-				i.ais_poreorderlevel, i.creation
+				i.ais_poreorderlevel, i.creation, i.item_group
 			from 
 				`tabItem Supplier` s 
 			inner join 
@@ -1351,9 +1359,30 @@ def get_us_data(filters):
 	item_search_settings = frappe.get_doc("Item Search Settings")
 	if item_search_settings.get("sales_report_url") is not None and item_search_settings.get("sales_report_url") != "":
 		us_request = requests.get(item_search_settings.get("sales_report_url"), 
-						auth=(item_search_settings.api_key, item_search_settings.api_secret),
+						auth=(item_search_settings.api_key, item_search_settings.get_password("api_secret),
 									params=filters)
+
 		if us_request.status_code == 200:
 			return us_request.json().get("message", {})
 	else:
 		return {}
+
+
+def get_item_group_parents(lower_item_group):
+	item_groups = []
+	item_group = lower_item_group
+
+	while item_group:
+		item_group = frappe.db.get_value("Item Group", item_group, "parent_item_group")
+		if item_group and item_group != "All Item Groups":
+			item_groups.append(item_group)
+
+	item_groups.insert(0, lower_item_group)
+	item_groups.reverse()
+
+	if len(item_groups) > 1:
+		item_groups = ">".join(item_groups)
+	else:
+		item_groups = item_groups[0]
+
+	return item_groups 

--- a/metactical/metactical/report/end_of_day_report___v3/end_of_day_report___v3.py
+++ b/metactical/metactical/report/end_of_day_report___v3/end_of_day_report___v3.py
@@ -198,7 +198,7 @@ def get_us_data(filters):
 	us_data = []
 	if item_search_settings.get("daily_report_url") is not None and item_search_settings.get("daily_report_url") != "":
 		us_request = requests.get(item_search_settings.get("daily_report_url"), 
-						auth=(item_search_settings.api_key, item_search_settings.api_secret),
+						auth=(item_search_settings.api_key, item_search_settings.get_password("api_secret")),
 									params={"date": filters.get("date")})
 		if us_request.status_code == 200:
 			for row in us_request.json().get("message", {}):

--- a/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
+++ b/metactical/metactical/report/end_of_day_report___v4/end_of_day_report___v4.py
@@ -207,7 +207,7 @@ def get_us_data(filters):
 	us_data = []
 	if item_search_settings.get("daily_report_url") is not None and item_search_settings.get("daily_report_url") != "":
 		us_request = requests.get(item_search_settings.get("daily_report_url"), 
-						auth=(item_search_settings.api_key, item_search_settings.api_secret),
+						auth=(item_search_settings.api_key, item_search_settings.get_password("api_secret")),
 									params={"date": filters.get("date")})
 		if us_request.status_code == 200:
 			for row in us_request.json().get("message", {}):

--- a/metactical/metactical/report/sales_report___for_admins/sales_report___for_admins.py
+++ b/metactical/metactical/report/sales_report___for_admins/sales_report___for_admins.py
@@ -802,7 +802,7 @@ def get_us_data(filters):
 	item_search_settings = frappe.get_doc("Item Search Settings")
 	if item_search_settings.get("sales_report_url") is not None and item_search_settings.get("sales_report_url") != "":
 		us_request = requests.get(item_search_settings.get("sales_report_url"), 
-						auth=(item_search_settings.api_key, item_search_settings.api_secret),
+						auth=(item_search_settings.api_key, item_search_settings.get_password("api_secret")),
 									params=filters)
 		if us_request.status_code == 200:
 			return us_request.json().get("message", {})

--- a/metactical/metactical/report/sales_report___full_v8/sales_report___full_v8.py
+++ b/metactical/metactical/report/sales_report___full_v8/sales_report___full_v8.py
@@ -823,7 +823,7 @@ def get_us_data(filters):
 	item_search_settings = frappe.get_doc("Item Search Settings")
 	if item_search_settings.get("sales_report_url") is not None and item_search_settings.get("sales_report_url") != "":
 		us_request = requests.get(item_search_settings.get("sales_report_url"), 
-						auth=(item_search_settings.api_key, item_search_settings.api_secret),
+						auth=(item_search_settings.api_key, item_search_settings.get_password("api_secret")),
 									params=filters)
 		if us_request.status_code == 200:
 			return us_request.json().get("message", {})

--- a/metactical/metactical/report/sales_report_v9/sales_report_v9.py
+++ b/metactical/metactical/report/sales_report_v9/sales_report_v9.py
@@ -1075,7 +1075,7 @@ def get_us_data(filters):
 	item_search_settings = frappe.get_doc("Item Search Settings")
 	if item_search_settings.get("sales_report_url") is not None and item_search_settings.get("sales_report_url") != "":
 		us_request = requests.get(item_search_settings.get("sales_report_url"), 
-						auth=(item_search_settings.api_key, item_search_settings.api_secret),
+						auth=(item_search_settings.api_key, item_search_settings.get_password("api_secret")),
 									params=filters)
 		if us_request.status_code == 200:
 			return us_request.json().get("message", {})

--- a/metactical/metactical/report/sales_report_with_item_class_suggest/sales_report_with_item_class_suggest.py
+++ b/metactical/metactical/report/sales_report_with_item_class_suggest/sales_report_with_item_class_suggest.py
@@ -1439,7 +1439,7 @@ def get_us_data(filters):
 	item_search_settings = frappe.get_doc("Item Search Settings")
 	if item_search_settings.get("sales_report_url") is not None and item_search_settings.get("sales_report_url") != "":
 		us_request = requests.get(item_search_settings.get("sales_report_url"), 
-						auth=(item_search_settings.api_key, item_search_settings.api_secret),
+						auth=(item_search_settings.api_key, item_search_settings.get_password("api_secret")),
 									params=filters)
 		if us_request.status_code == 200:
 			return us_request.json().get("message", {})

--- a/metactical/www/itemsearchnew.py
+++ b/metactical/www/itemsearchnew.py
@@ -170,7 +170,7 @@ def get_items(search_value="", offset=0):
 		#Get US data
 		us_data = {}
 		if item_search_settings.get("us_url") is not None and item_search_settings.get("us_url") != "":
-			us_request = requests.get(item_search_settings.us_url, auth=(item_search_settings.api_key, item_search_settings.api_secret),
+			us_request = requests.get(item_search_settings.us_url, auth=(item_search_settings.api_key, item_search_settings.get_password("api_secret")),
 										params={"search_value": search_value})
 			if us_request.status_code == 200:
 				for item in us_request.json().get("message", {}):


### PR DESCRIPTION
changed  item_search_settings.api_secret  to  item_search_settings.get_password("api_secret") as directly passing password fields is restricted in v14.