### PR TITLE
fix: update purchase order item assignment to purchase receipt items on PR creation

### DIFF
--- a/metactical/custom_scripts/purchase_receipt/purchase_receipt.py
+++ b/metactical/custom_scripts/purchase_receipt/purchase_receipt.py
@@ -11,7 +11,7 @@ class CustomPurchaseReceipt(PurchaseReceipt):
 		if self.purchase_order:
 			for d in self.items:
 				d.purchase_order = self.purchase_order
-				d.purchase_order_item = frappe.db.get_value("Purchase Order Item", {"item_code": d.item_code, "parent": d.purchase_order}, "name")
+				d.purchase_order_item = frappe.db.get_value("Purchase Order Item", {"item_code": d.item_code, "name":d.purchase_order_item, "parent": d.purchase_order}, "name")
 				if not d.purchase_order_item:
 					frappe.throw("Purchase Order Missing for Item {} at Row {}".format(d.item_code, str(d.idx)))
 	


### PR DESCRIPTION
Issue: When an item is added multiple times to an order, creating a Purchase Receipt from the order causes both items in the receipt to reference the ID/Name of the last occurrence of the item in the Purchase Order.

Sulution: Updated the filter query to make it more specific to the purchase order items