### PR TITLE
fix: re-create inventory output document

### DIFF
--- a/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
+++ b/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
@@ -99,6 +99,8 @@ def update_item_inventory_output(item_code, net_available_bins = {}, voucher_typ
 			item_inventory_output.item_inventory_output_list = data
 			try:
 				item_inventory_output.insert()
+				frappe.db.commit()
+
 			except frappe.DuplicateEntryError:
 				item_inventory_output_doc = frappe.db.get_value('Item Inventory Output', {'item_code': item_code})
 				if item_inventory_output_doc:
@@ -110,11 +112,10 @@ def update_item_inventory_output(item_code, net_available_bins = {}, voucher_typ
 
 			try:
 				item_inventory_output.save()
+				frappe.db.commit()
 			except:
 				if item_inventory_output_doc:
 					update_doc(item_inventory_output_doc, total_available_qty, data, item_code, voucher_type)
-
-		frappe.db.commit()
 
 	except Exception as e:
 		frappe.log_error(title=f"Inventory Update ({voucher_type}) - {item_code}", message=frappe.get_traceback())
@@ -128,8 +129,14 @@ def update_doc(docname, total_available_qty, data, item_code, voucher_type, roun
 		item_inventory_output.qoh = total_available_qty
 		item_inventory_output.save()
 	except Exception as e:
-		if round > 3:
-			frappe.log_error(title=f"Inventory Update Failed ({voucher_type}) - {item_code}", message=frappe.get_traceback())
+		if round > 2:
+			frappe.delete_doc('Item Inventory Output', docname)
+			item_inventory_output = frappe.new_doc('Item Inventory Output')
+			item_inventory_output.item_code = item_code
+			item_inventory_output.qoh = total_available_qty
+			item_inventory_output.item_inventory_output_list = data
+			item_inventory_output.insert()
+			frappe.db.commit()
 		else:
 			sys.stdout.flush()
 			time.sleep(2)


### PR DESCRIPTION
fix: re-create inventory output document when there is a TimestampMismatch Error occurs