### PR TITLE
fix: Item inventory output

### DIFF
--- a/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
+++ b/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
@@ -125,10 +125,9 @@ def update_doc(docname, total_available_qty, data, item_code, voucher_type, roun
 		item_inventory_output.item_inventory_output_list = data
 		item_inventory_output.qoh = total_available_qty
 		item_inventory_output.save()
-		
 	except Exception as e:
 		if round > 5:
-			frappe.log_error(title=f"Inventory Update Faile ({voucher_type}) - {item_code}", message=frappe.get_traceback())
+			frappe.log_error(title=f"Inventory Update Failed ({voucher_type}) - {item_code}", message=frappe.get_traceback())
 			return
 		else:
 			time.sleep(3)

--- a/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
+++ b/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
@@ -98,6 +98,8 @@ def update_item_inventory_output(item_code, net_available_bins = {}, voucher_typ
 			item_inventory_output.item_inventory_output_list = data
 			try:
 				item_inventory_output.insert()
+				frappe.db.commit()
+
 			except frappe.DuplicateEntryError:
 				item_inventory_output_doc = frappe.db.get_value('Item Inventory Output', {'item_code': item_code})
 				if item_inventory_output_doc:
@@ -109,11 +111,10 @@ def update_item_inventory_output(item_code, net_available_bins = {}, voucher_typ
 
 			try:
 				item_inventory_output.save()
+				frappe.db.commit()
 			except:
 				if item_inventory_output_doc:
 					update_doc(item_inventory_output_doc, total_available_qty, data, item_code, voucher_type)
-
-		frappe.db.commit()
 
 	except Exception as e:
 		frappe.log_error(title=f"Inventory Update ({voucher_type}) - {item_code}", message=frappe.get_traceback())
@@ -127,9 +128,14 @@ def update_doc(docname, total_available_qty, data, item_code, voucher_type, roun
 		item_inventory_output.qoh = total_available_qty
 		item_inventory_output.save()
 	except Exception as e:
-		if round > 3:
-			frappe.log_error(title=f"Inventory Update Failed ({voucher_type}) - {item_code}", message=frappe.get_traceback())
-			return
+		if round > 2:
+			frappe.delete_doc('Item Inventory Output', docname)
+			item_inventory_output = frappe.new_doc('Item Inventory Output')
+			item_inventory_output.item_code = item_code
+			item_inventory_output.qoh = total_available_qty
+			item_inventory_output.item_inventory_output_list = data
+			item_inventory_output.insert()
+			frappe.db.commit()
 		else:
 			time.sleep(3)
 			update_doc(docname, total_available_qty, data, item_code, voucher_type, round+1)

--- a/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
+++ b/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
@@ -119,12 +119,17 @@ def update_item_inventory_output(item_code, net_available_bins = {}, voucher_typ
 		frappe.log_error(title=f"Inventory Update ({voucher_type}) - {item_code}", message=frappe.get_traceback())
 		frappe.db.rollback()
 
-def update_doc(docname, total_available_qty, data, item_code, voucher_type):
+def update_doc(docname, total_available_qty, data, item_code, voucher_type, round=0):
 	try:
 		item_inventory_output = frappe.get_doc('Item Inventory Output', docname)
 		item_inventory_output.item_inventory_output_list = data
 		item_inventory_output.qoh = total_available_qty
 		item_inventory_output.save()
+		
 	except Exception as e:
-		frappe.log_error(title=f"Inventory Update Failed ({voucher_type}) - {item_code}", message=frappe.get_traceback())
-		frappe.db.rollback()
+		if round > 5:
+			frappe.log_error(title=f"Inventory Update Faile ({voucher_type}) - {item_code}", message=frappe.get_traceback())
+			return
+		else:
+			time.sleep(3)
+			update_doc(docname, total_available_qty, data, item_code, voucher_type, round+1)

--- a/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
+++ b/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
@@ -122,11 +122,12 @@ def update_item_inventory_output(item_code, net_available_bins = {}, voucher_typ
 def update_doc(docname, total_available_qty, data, item_code, voucher_type, round=0):
 	try:
 		item_inventory_output = frappe.get_doc('Item Inventory Output', docname)
+		item_inventory_output.reload()
 		item_inventory_output.item_inventory_output_list = data
 		item_inventory_output.qoh = total_available_qty
 		item_inventory_output.save()
 	except Exception as e:
-		if round > 5:
+		if round > 3:
 			frappe.log_error(title=f"Inventory Update Failed ({voucher_type}) - {item_code}", message=frappe.get_traceback())
 			return
 		else:


### PR DESCRIPTION
Issue: The Item Inventory Update doctype is being updated from twice when doing material transfer but failing on the second update because of timestampmismatcherror

Resolution: Retry for 6 seconds and if it continue fails, the script will delete the document and create a new one with updated information.