### PR TITLE
fix: added additional check for the stock quantity to active warehouses

### DIFF
--- a/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
+++ b/metactical/metactical/doctype/item_inventory_output/item_inventory_output.py
@@ -29,6 +29,14 @@ def get_all_bins(item_code):
 		fields=["warehouse", "actual_qty", "reserved_qty"]
 	)
 
+	other_active_warehouse_bins = frappe.get_all(
+		'Bin', 
+		filters={'item_code': item_code, "warehouse":["like", "%activestock%"]}, 
+		fields=["warehouse", "actual_qty", "reserved_qty"]
+	)
+
+	all_bins.extend(other_active_warehouse_bins)
+
 	return all_bins
 	
 def update_item_inventory_output(item_code, net_available_bins = {}, voucher_type=None):


### PR DESCRIPTION
Issue: Item inventory output doctype were not being updated for usa instance because of the warehouse naming structure. 

fix: added a warehouse filter to check warehouses with "activestock" label besides "active stock"