### PR TITLE
Website specifications

### DIFF
--- a/metactical/custom_scripts/item_group/item_group.js
+++ b/metactical/custom_scripts/item_group/item_group.js
@@ -36,7 +36,7 @@ frappe.ui.form.on("Item Group", {
 
 function copy_specs(item_group, overwrite, add_missing_labels, sync_to_websites) {
     frappe.call({
-        method: "metactical.custom_scripts.item_group.item_group.copy_specification_from_item_group",
+        method: "metactical.custom_scripts.item_group.item_group.copy_specifications_to_items",
         args: {
             item_group: item_group,
             overwrite: overwrite,

--- a/metactical/custom_scripts/item_group/item_group.js
+++ b/metactical/custom_scripts/item_group/item_group.js
@@ -1,0 +1,44 @@
+// Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+// License: GNU General Public License v3. See license.txt
+
+frappe.ui.form.on("Item Group", {
+    refresh: function (frm) {
+        frm.add_custom_button(__("Copy spec to items"), function () {
+            
+            frappe.prompt([{
+                label: 'Overwrite existing spec?',
+                fieldname: 'overwrite',
+                fieldtype: 'Check'
+            },{
+                label: 'Add missing labels to existing items?',
+                fieldname: 'add_missing_labels',
+                fieldtype: 'Check'
+            }], 
+            (values) => {
+                if (values.overwrite){
+                    frappe.confirm('This will clear all existing specs on items in this group and copy the specs from this group. Are you sure you want to proceed?',
+                        () => {
+                            copy_specs(frm.doc.name, values.overwrite, values.add_missing_labels);
+                        },)
+                } else {
+                    copy_specs(frm.doc.name, values.overwrite, values.add_missing_labels);
+                }
+                
+                
+            });
+
+            
+		});
+	},
+});
+
+function copy_specs(item_group, overwrite, add_missing_labels) {
+    frappe.call({
+        method: "metactical.custom_scripts.item_group.item_group.copy_specification_from_item_group",
+        args: {
+            item_group: item_group,
+            overwrite: overwrite,
+            add_missing_labels: add_missing_labels
+        }
+    });
+}

--- a/metactical/custom_scripts/item_group/item_group.js
+++ b/metactical/custom_scripts/item_group/item_group.js
@@ -13,32 +13,38 @@ frappe.ui.form.on("Item Group", {
                 label: 'Add missing labels to existing items?',
                 fieldname: 'add_missing_labels',
                 fieldtype: 'Check'
-            }], 
+            },
+            {
+                label: "Sync to websites",
+                fieldname: "sync_to_websites",
+                fieldtype: "Check"
+            }
+        ], 
             (values) => {
                 if (values.overwrite){
                     frappe.confirm('This will clear all existing specs on items in this group and copy the specs from this group. Are you sure you want to proceed?',
                         () => {
-                            copy_specs(frm.doc.name, values.overwrite, values.add_missing_labels);
+                            copy_specs(frm.doc.name, values.overwrite, values.add_missing_labels, values.sync_to_websites);
                         },)
                 } else {
-                    copy_specs(frm.doc.name, values.overwrite, values.add_missing_labels);
+                    copy_specs(frm.doc.name, values.overwrite, values.add_missing_labels, values.sync_to_websites);
                 }
-                
-                
             });
-
-            
 		});
 	},
 });
 
-function copy_specs(item_group, overwrite, add_missing_labels) {
+function copy_specs(item_group, overwrite, add_missing_labels, sync_to_websites) {
     frappe.call({
         method: "metactical.custom_scripts.item_group.item_group.copy_specification_from_item_group",
         args: {
             item_group: item_group,
             overwrite: overwrite,
-            add_missing_labels: add_missing_labels
+            add_missing_labels: add_missing_labels,
+            sync_to_websites: sync_to_websites
+        },
+        callback: function (r) {
+            frappe.msgprint("The task has been enqueued as a background job")
         }
     });
 }

--- a/metactical/custom_scripts/item_group/item_group.py
+++ b/metactical/custom_scripts/item_group/item_group.py
@@ -3,7 +3,7 @@ from frappe.integrations.doctype.webhook.webhook import enqueue_webhook
 
 
 @frappe.whitelist()
-def copy_specification_from_item_group(item_group, overwrite, add_missing_labels, sync_to_websites):
+def copy_specifications_to_items(item_group, overwrite, add_missing_labels, sync_to_websites):
     chunk_size = 2500
     start = 0
     webhook = frappe.get_doc("Webhook", {"webhook_doctype": "Item", "enabled": 1, "webhook_docevent": "on_update"})
@@ -38,7 +38,7 @@ def copy_specification_from_item_group(item_group, overwrite, add_missing_labels
                 start = start + chunk_size
                 
     except Exception as e:
-        frappe.log_error(title="Error in copy_specification_from_item_group", message=frappe.get_traceback())
+        frappe.log_error(title="Error in copy_specifications_to_items", message=frappe.get_traceback())
         frappe.msgprint(f"Error: {e}")    
 
 def process_item_specifications(items, web_spec_labels, overwrite, add_missing_labels, webhook, sync_to_websites):

--- a/metactical/custom_scripts/item_group/item_group.py
+++ b/metactical/custom_scripts/item_group/item_group.py
@@ -1,0 +1,76 @@
+import frappe
+
+@frappe.whitelist()
+def copy_specification_from_item_group(item_group, overwrite, add_missing_labels):
+    chunk_size = 3
+    start = 0
+    # Get a batch of items
+    # Fetch specifications only once per batch
+    web_spec_labels = frappe.get_doc('Item Group', item_group).get('neb_website_specifications')
+    
+    items = ['test']
+    while len(items) > 0:
+        items = frappe.get_all(
+            'Item',
+            filters={'item_group': item_group},
+            fields=['name'],
+            limit_start=start,
+            limit_page_length=chunk_size
+        )
+
+        if items:
+            frappe.enqueue(
+                process_item_specifications,
+                items=items,
+                web_spec_labels=web_spec_labels,
+                overwrite=overwrite,
+                queue='default'
+            )
+            
+            start = start + chunk_size
+
+
+def process_item_specifications(items, web_spec_labels, overwrite, add_missing_labels):
+    """
+    Process the specifications for a single item.
+    """
+    for item in items:
+        item_code = item['name']
+        # Check if the item already has specifications
+        existing_specs = frappe.get_all(
+            'MT Item Website Specification',
+            filters={'parent': item_code},
+            fields=['name', 'label']
+        )
+
+        if existing_specs and int(overwrite):
+            for spec in existing_specs:
+                frappe.delete_doc('MT Item Website Specification', spec['name'])
+        elif not int(overwrite) and existing_specs and int(add_missing_labels):
+            existing_labels = [spec['label'] for spec in existing_specs]
+            for label in web_spec_labels:
+                if label.label not in existing_labels:    
+                    new_spec = frappe.get_doc({
+                        'doctype': 'MT Item Website Specification',
+                        'parent': item_code,
+                        'parenttype': 'Item',
+                        'parentfield': 'neb_website_specifications',
+                        'label': label.label,
+                        'mandatory': label.mandatory,
+                    })
+                    new_spec.insert()
+            continue
+        elif not int(overwrite) and existing_specs and not int(add_missing_labels):
+            continue
+        
+        # Insert new specifications
+        for spec in web_spec_labels:
+            new_spec = frappe.get_doc({
+                'doctype': 'MT Item Website Specification',
+                'parent': item_code,
+                'parenttype': 'Item',
+                'parentfield': 'neb_website_specifications',
+                'label': spec.label,
+                'mandatory': spec.mandatory,
+            })
+            new_spec.insert()

--- a/metactical/custom_scripts/item_group/item_group.py
+++ b/metactical/custom_scripts/item_group/item_group.py
@@ -1,76 +1,108 @@
 import frappe
+from frappe.integrations.doctype.webhook.webhook import enqueue_webhook
+
 
 @frappe.whitelist()
-def copy_specification_from_item_group(item_group, overwrite, add_missing_labels):
-    chunk_size = 3
+def copy_specification_from_item_group(item_group, overwrite, add_missing_labels, sync_to_websites):
+    chunk_size = 2500
     start = 0
+    webhook = frappe.get_doc("Webhook", {"webhook_doctype": "Item", "enabled": 1, "webhook_docevent": "on_update"})
+    
     # Get a batch of items
     # Fetch specifications only once per batch
     web_spec_labels = frappe.get_doc('Item Group', item_group).get('neb_website_specifications')
     
-    items = ['test']
-    while len(items) > 0:
-        items = frappe.get_all(
-            'Item',
-            filters={'item_group': item_group},
-            fields=['name'],
-            limit_start=start,
-            limit_page_length=chunk_size
-        )
-
-        if items:
-            frappe.enqueue(
-                process_item_specifications,
-                items=items,
-                web_spec_labels=web_spec_labels,
-                overwrite=overwrite,
-                queue='default'
+    try:
+        items = ['test']
+        while len(items) > 0:
+            items = frappe.get_all(
+                'Item',
+                filters={'item_group': item_group, 'disabled': 0},
+                fields=['name'],
+                limit_start=start,
+                limit_page_length=chunk_size
             )
-            
-            start = start + chunk_size
 
+            if items:
+                frappe.enqueue(
+                    process_item_specifications,
+                    items=items,
+                    web_spec_labels=web_spec_labels,
+                    overwrite=overwrite,
+                    add_missing_labels=add_missing_labels,
+                    webhook=webhook,
+                    sync_to_websites=sync_to_websites,
+                    queue='long'
+                )
+                
+                start = start + chunk_size
+                
+    except Exception as e:
+        frappe.log_error(title="Error in copy_specification_from_item_group", message=frappe.get_traceback())
+        frappe.msgprint(f"Error: {e}")    
 
-def process_item_specifications(items, web_spec_labels, overwrite, add_missing_labels):
+def process_item_specifications(items, web_spec_labels, overwrite, add_missing_labels, webhook, sync_to_websites):
     """
     Process the specifications for a single item.
     """
-    for item in items:
-        item_code = item['name']
-        # Check if the item already has specifications
-        existing_specs = frappe.get_all(
-            'MT Item Website Specification',
-            filters={'parent': item_code},
-            fields=['name', 'label']
-        )
+    try:
+        for item in items:
+            item_code = item['name']
+            # Check if the item already has specifications
+            existing_specs = frappe.get_all(
+                'MT Item Website Specification',
+                filters={'parent': item_code},
+                fields=['name', 'label']
+            )
 
-        if existing_specs and int(overwrite):
-            for spec in existing_specs:
-                frappe.delete_doc('MT Item Website Specification', spec['name'])
-        elif not int(overwrite) and existing_specs and int(add_missing_labels):
-            existing_labels = [spec['label'] for spec in existing_specs]
-            for label in web_spec_labels:
-                if label.label not in existing_labels:    
-                    new_spec = frappe.get_doc({
-                        'doctype': 'MT Item Website Specification',
-                        'parent': item_code,
-                        'parenttype': 'Item',
-                        'parentfield': 'neb_website_specifications',
-                        'label': label.label,
-                        'mandatory': label.mandatory,
-                    })
-                    new_spec.insert()
-            continue
-        elif not int(overwrite) and existing_specs and not int(add_missing_labels):
-            continue
+            if existing_specs and int(overwrite):
+                for spec in existing_specs:
+                    frappe.delete_doc('MT Item Website Specification', spec['name'])
+            elif not int(overwrite) and existing_specs and int(add_missing_labels):
+                existing_labels = [spec['label'] for spec in existing_specs]
+                new_spec_found = False
+                
+                for label in web_spec_labels:
+                    if label.label not in existing_labels:    
+                        new_spec_found = True
+                        insert_web_specification(item_code, label)
+                        
+                if not new_spec_found and int(sync_to_websites):
+                    trigger_item_update(item_code, webhook)
+                    
+                continue
+            elif not int(overwrite) and existing_specs and not int(add_missing_labels):
+                continue
+            
+            # Insert new specifications
+            for spec in web_spec_labels:
+                insert_web_specification(item_code, spec)
+                
+            if int(sync_to_websites):
+                trigger_item_update(item_code, webhook)
+                
+    except Exception as e: 
+        frappe.log_error(title="Error in process_item_specifications", message=frappe.get_traceback())
+            
+def insert_web_specification(item_code, spec):
+    new_spec = frappe.get_doc({
+        'doctype': 'MT Item Website Specification',
+        'parent': item_code,
+        'parenttype': 'Item',
+        'parentfield': 'neb_website_specifications',
+        'label': spec.label or '',
+        'mandatory': spec.mandatory or 0,
+        'sort_order': spec.sort_order or 0,
+        'description': spec.description or ''
+    })
+    new_spec.insert()
+    
+            
+def trigger_item_update(item_code, webhook):
+    if webhook:
         
-        # Insert new specifications
-        for spec in web_spec_labels:
-            new_spec = frappe.get_doc({
-                'doctype': 'MT Item Website Specification',
-                'parent': item_code,
-                'parenttype': 'Item',
-                'parentfield': 'neb_website_specifications',
-                'label': spec.label,
-                'mandatory': spec.mandatory,
-            })
-            new_spec.insert()
+        item = frappe.get_doc('Item', item_code)
+        webhook = frappe.get_doc('Webhook', webhook.name)
+        
+        print(f"Item {item_code} updated. Triggering webhook {webhook.name}...")
+        enqueue_webhook(item, webhook)

--- a/metactical/hooks.py
+++ b/metactical/hooks.py
@@ -49,7 +49,8 @@ doctype_js = {
 	"Task": "custom_scripts/task/task.js",
 	"Warehouse": "custom_scripts/warehouse/warehouse.js",
 	"Contact": "custom_scripts/contact/contact.js",
-	"Item": "custom_scripts/item/item.js"
+	"Item": "custom_scripts/item/item.js",
+	"Item Group": "custom_scripts/item_group/item_group.js"
 }
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 #doctype_list_js = {"doctype" : "public/js/doctype_list.js"}


### PR DESCRIPTION
This pull request introduces a new feature for copying specifications from an item group to individual items in the ERP system. The main changes include the addition of a custom button in the `Item Group` form, the implementation of the backend logic to handle the copying process, and the registration of the new script in the hooks file.

### New Feature: Copy Specifications from Item Group to Items

* [`metactical/custom_scripts/item_group/item_group.js`](diffhunk://#diff-c59a89e0fadf4c0372885c0ee31a03fff7575186956067397002c3f77b0c50faR1-R50): Added a custom button "Copy spec to items" in the `Item Group` form that prompts the user for options and triggers the specification copying process.

* [`metactical/custom_scripts/item_group/item_group.py`](diffhunk://#diff-95afe936c7e10c6f07fd194f4847fdfae3d18a96c63006213da79bd805c6b403R1-R108): Implemented the backend logic to handle copying specifications from an item group to individual items. This includes functions to process item specifications, insert new specifications, and trigger item updates via webhooks.

* [`metactical/hooks.py`](diffhunk://#diff-870b9ff115be3ec2e7494821c085b81747bd37611f77c4804a4e552c1587d8f1L52-R53): Registered the new `item_group.js` script in the hooks file to ensure it is loaded for the `Item Group` doctype.