### PR TITLE
Website specs: sync website items

### DIFF
--- a/metactical/custom_scripts/item_group/item_group.py
+++ b/metactical/custom_scripts/item_group/item_group.py
@@ -7,7 +7,11 @@ def copy_specifications_to_items(item_group, overwrite, add_missing_labels, sync
     chunk_size = 2500
     start = 0        
     webhook = frappe.db.exists("Webhook", {"webhook_doctype": "Item", "enabled": 1, "webhook_docevent": "on_update"})
-    
+    if webhook:
+        webhook = frappe.get_doc("Webhook", webhook)
+    else:
+        webhook = None
+        
     # Get a batch of items
     # Fetch specifications only once per batch
     web_spec_labels = frappe.get_doc('Item Group', item_group).get('neb_website_specifications')
@@ -105,10 +109,7 @@ def insert_web_specification(item_code, spec):
 def trigger_item_update(item_code, webhook):
     if webhook:
         
-        item = frappe.get_doc('Item', item_code)
-        webhook = frappe.get_doc('Webhook', webhook)
-        
-        print(f"Item {item_code} updated. Triggering webhook {webhook.name}...")
+        item = frappe.get_doc('Item', item_code)        
         enqueue_webhook(item, webhook)
         
 def update_website_items(item_code):

--- a/metactical/custom_scripts/item_group/item_group.py
+++ b/metactical/custom_scripts/item_group/item_group.py
@@ -5,8 +5,8 @@ from frappe.integrations.doctype.webhook.webhook import enqueue_webhook
 @frappe.whitelist()
 def copy_specifications_to_items(item_group, overwrite, add_missing_labels, sync_to_websites):
     chunk_size = 2500
-    start = 0
-    webhook = frappe.get_doc("Webhook", {"webhook_doctype": "Item", "enabled": 1, "webhook_docevent": "on_update"})
+    start = 0        
+    webhook = frappe.db.exists("Webhook", {"webhook_doctype": "Item", "enabled": 1, "webhook_docevent": "on_update"})
     
     # Get a batch of items
     # Fetch specifications only once per batch
@@ -36,7 +36,7 @@ def copy_specifications_to_items(item_group, overwrite, add_missing_labels, sync
                 )
                 
                 start = start + chunk_size
-                
+  
     except Exception as e:
         frappe.log_error(title="Error in copy_specifications_to_items", message=frappe.get_traceback())
         frappe.msgprint(f"Error: {e}")    
@@ -66,10 +66,12 @@ def process_item_specifications(items, web_spec_labels, overwrite, add_missing_l
                     if label.label not in existing_labels:    
                         new_spec_found = True
                         insert_web_specification(item_code, label)
-                        
+                
+                update_website_items(item_code)
                 if not new_spec_found and int(sync_to_websites):
                     trigger_item_update(item_code, webhook)
-                    
+                
+                frappe.db.commit()
                 continue
             elif not int(overwrite) and existing_specs and not int(add_missing_labels):
                 continue
@@ -77,10 +79,12 @@ def process_item_specifications(items, web_spec_labels, overwrite, add_missing_l
             # Insert new specifications
             for spec in web_spec_labels:
                 insert_web_specification(item_code, spec)
-                
+            
+            update_website_items(item_code)
             if int(sync_to_websites):
                 trigger_item_update(item_code, webhook)
                 
+            frappe.db.commit()
     except Exception as e: 
         frappe.log_error(title="Error in process_item_specifications", message=frappe.get_traceback())
             
@@ -102,7 +106,35 @@ def trigger_item_update(item_code, webhook):
     if webhook:
         
         item = frappe.get_doc('Item', item_code)
-        webhook = frappe.get_doc('Webhook', webhook.name)
+        webhook = frappe.get_doc('Webhook', webhook)
         
         print(f"Item {item_code} updated. Triggering webhook {webhook.name}...")
         enqueue_webhook(item, webhook)
+        
+def update_website_items(item_code):
+    website_items = frappe.get_all("Website Item", filters={"item_code": item_code}, fields=["name"])
+    if website_items:
+        for item in website_items:
+            website_item = frappe.get_doc("Website Item", item.name)
+            website_item.neb_website_specifications = []
+            website_item.website_specifications = []
+            website_item.save()
+            
+            item = frappe.get_doc('Item', item_code)
+            for spec in item.neb_website_specifications:
+                website_spec = frappe.new_doc("MT Item Website Specification")
+                website_spec.label = spec.label
+                website_spec.description = spec.description
+                website_spec.mandatory = spec.mandatory
+                website_spec.parent = website_item.name
+                website_spec.parenttype = website_item.doctype
+                website_spec.parentfield = "neb_website_specifications"
+                website_spec.save(ignore_permissions=True)
+
+                main_website_spec = frappe.new_doc("Item Website Specification")
+                main_website_spec.label = spec.label
+                main_website_spec.description = spec.description
+                main_website_spec.parent = website_item.name
+                main_website_spec.parenttype = website_item.doctype
+                main_website_spec.parentfield = "website_specifications"
+                main_website_spec.save(ignore_permissions=True)


### PR DESCRIPTION
This pull request includes several changes to the `metactical/custom_scripts/item_group/item_group.py` file to improve the handling of item specifications and website updates. The most important changes include modifying how webhooks are fetched, adding a new function to update website items, and ensuring database commits are made after processing item specifications.

Improvements to webhook handling:

* Changed the method to fetch the webhook from `frappe.get_doc` to `frappe.db.exists` to check for the existence of the webhook before fetching it.
* Modified the `trigger_item_update` function to directly use the webhook object instead of fetching it again.

Enhancements to item and website updates:

* Added the `update_website_items` function to sync website items based on item specifications. This function clears existing specifications and re-adds them from the item.
* Ensured `update_website_items` is called after inserting web specifications in the `process_item_specifications` function. [[1]](diffhunk://#diff-95afe936c7e10c6f07fd194f4847fdfae3d18a96c63006213da79bd805c6b403R70-R74) [[2]](diffhunk://#diff-95afe936c7e10c6f07fd194f4847fdfae3d18a96c63006213da79bd805c6b403R83-R87)
* Added `frappe.db.commit()` calls to ensure changes are committed to the database after processing item specifications. [[1]](diffhunk://#diff-95afe936c7e10c6f07fd194f4847fdfae3d18a96c63006213da79bd805c6b403R70-R74) [[2]](diffhunk://#diff-95afe936c7e10c6f07fd194f4847fdfae3d18a96c63006213da79bd805c6b403R83-R87)