### PR TITLE
POS API - assign warehouse for items from POS Profile

### DIFF
--- a/metactical/custom_scripts/utils/pos_api.py
+++ b/metactical/custom_scripts/utils/pos_api.py
@@ -264,6 +264,7 @@ def get_taxes(form_data):
             
 def get_items(form_data):
     items = []
+    warehouse = frappe.db.get_value('POS Profile', form_data['POSProfile'] + ' Operators', 'warehouse')
     for item in form_data['Items']:
         item_code = item['ItemCode']
         rate = item['Rate']
@@ -275,7 +276,7 @@ def get_items(form_data):
             'rate': rate,
             'qty': qty,
             'discount_percentage': item['Discount'],
-            'warehouse': 'W01-WHS-Active Stock - ICL',
+            'warehouse': warehouse if warehouse else 'W01-WHS-Active Stock - ICL'
         }
         
         if item_code == "2":

--- a/metactical/custom_scripts/utils/pos_api.py
+++ b/metactical/custom_scripts/utils/pos_api.py
@@ -273,7 +273,7 @@ def get_items(form_data):
         
         item_info = {
             'item_code': item_code,
-            'rate': rate,
+            'price_list_rate': rate,
             'qty': qty,
             'discount_percentage': item['Discount'],
             'warehouse': warehouse if warehouse else 'W01-WHS-Active Stock - ICL'

--- a/metactical/metactical/report/item_details_for_pos/item_details_for_pos.py
+++ b/metactical/metactical/report/item_details_for_pos/item_details_for_pos.py
@@ -23,7 +23,7 @@ def get_data(filters):
 	if not price_list:
 		frappe.throw("Please set default price list in Stock Settings or POS Profile")
   
-	warehouses = frappe.db.get_list("SB Warehouse Inventory Sync", filters={"parent": pos_profile.ifw_default_lead_source}, fields=["warehouse"])
+	warehouses = frappe.db.get_all("SB Warehouse Inventory Sync", filters={"parent": pos_profile.ifw_default_lead_source}, fields=["warehouse"])
 	if not warehouses:
 		frappe.throw("No warehouses found for the selected in the <a href='/app/lead-source/{0}'>Lead Source</a>".format(pos_profile.ifw_default_lead_source))
  


### PR DESCRIPTION
This pull request includes several changes to the `metactical` module, focusing on improving the handling of warehouse data and price rates in the POS API and item details report.

Improvements to warehouse data handling:

* [`metactical/custom_scripts/utils/pos_api.py`](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baR267): Added a query to fetch the warehouse associated with the POS Profile in the `get_items` function. Modified the `warehouse` field to use the fetched warehouse value or a default value if not available. [[1]](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baR267) [[2]](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baL275-R279)

Enhancements to price rate handling:

* [`metactical/custom_scripts/utils/pos_api.py`](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baL275-R279): Changed the key from `rate` to `price_list_rate` in the `item_info` dictionary within the `get_items` function.

Code improvement in fetching warehouse data:

* [`metactical/metactical/report/item_details_for_pos/item_details_for_pos.py`](diffhunk://#diff-e803940e75ffbb5b30ad3fd0ae56a1ff288438ae53918cb8e4d119f4ca8a6c3cL26-R26): Updated the method used to fetch warehouse data from `frappe.db.get_list` to `frappe.db.get_all` to fix permission issue.