### PR TITLE
Ignore pricing rule for order creation and include pricing rules with no specific Price List

### DIFF
--- a/metactical/custom_scripts/utils/pos_api.py
+++ b/metactical/custom_scripts/utils/pos_api.py
@@ -125,11 +125,12 @@ def create_sales_order(form_data, customer):
         'delivery_date': frappe.utils.today(),
         'company_address': company_address,
         'source': form_data['LeadSource'],
+        'ignore_pricing_rule': 1,
         'contact_person': frappe.db.get_value('Customer', customer, 'customer_primary_contact'),
         'additional_discount_percentage': form_data['OverallDiscount'],
         "owner": form_data['SalesPerson'],
     }
-    
+        
     items = get_items(form_data)
     so_data.update({'items': items})
     
@@ -138,7 +139,8 @@ def create_sales_order(form_data, customer):
         
     frappe.set_user(form_data['SalesPerson'])
     sales_order = frappe.get_doc(so_data)
-    sales_order.insert()
+
+    sales_order.insert(ignore_permissions=True)
     frappe.set_user("Administrator")
     frappe.db.commit()
             
@@ -278,7 +280,7 @@ def get_items(form_data):
             'discount_percentage': item['Discount'],
             'warehouse': warehouse if warehouse else 'W01-WHS-Active Stock - ICL'
         }
-        
+
         if item_code == "2":
             item_info.update({'item_name': item_name})
         

--- a/metactical/metactical/report/item_details_for_pos/item_details_for_pos.py
+++ b/metactical/metactical/report/item_details_for_pos/item_details_for_pos.py
@@ -74,12 +74,12 @@ def get_data(filters):
 				`tabPricing Rule` ON `tabPricing Rule`.name = `tabPricing Rule Item Code`.parent
 			WHERE
 				`tabPricing Rule Item Code`.item_code = '{item.item_code}'
-				AND `tabPricing Rule`.for_price_list = '{price_list}'
+				AND (`tabPricing Rule`.for_price_list = '{price_list}' or `tabPricing Rule`.for_price_list is NULL)
 				AND `tabPricing Rule`.disable = 0
 				AND `tabPricing Rule Item Code`.parent IS NOT NULL
+				AND `tabPricing Rule`.valid_upto >= CURDATE()
 			ORDER BY
-				`tabPricing Rule`.priority DESC,
-				`tabPricing Rule`.modified Desc
+				CAST(`tabPricing Rule`.priority AS UNSIGNED) DESC
 			LIMIT 1;
 		""", as_dict=1)
   


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and reliability of the point of sale (POS) system. The most important changes involve modifications to the sales order creation process and the item details report.

Changes to sales order creation:

* [`metactical/custom_scripts/utils/pos_api.py`](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baR128): Added `ignore_pricing_rule` to the sales order data to bypass certain pricing rules.
* [`metactical/custom_scripts/utils/pos_api.py`](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baL141-R143): Modified the `insert` method to use `ignore_permissions=True` to ensure the sales order is inserted regardless of user permissions.

Changes to item details report:

* [`metactical/metactical/report/item_details_for_pos/item_details_for_pos.py`](diffhunk://#diff-e803940e75ffbb5b30ad3fd0ae56a1ff288438ae53918cb8e4d119f4ca8a6c3cL77-R82): Enhanced the query to include pricing rules where `for_price_list` is `NULL` and to ensure the pricing rule is valid as of the current date. Additionally, adjusted the sorting logic for pricing rules by casting `priority` to an unsigned integer.