### PR TITLE
fix: add callback to copy branch pairing link to clipboard and handle email sending errors

### DIFF
--- a/metactical/custom_scripts/pos_profile/pos_profile.js
+++ b/metactical/custom_scripts/pos_profile/pos_profile.js
@@ -9,6 +9,12 @@ frappe.ui.form.on('POS Profile User', {
             },
             freeze: true,
             freeze_message: __("Sending Welcome Email..."),
+            callback: function(res) {
+                if (res.url){
+                    frappe.utils.copy_to_clipboard(res.url);
+                    frappe.set_alert(__("Branch Pairing Link Copied to Clipboard"), 5);
+                }
+            }
         });
     }
 });

--- a/metactical/custom_scripts/pos_profile/pos_profile.py
+++ b/metactical/custom_scripts/pos_profile/pos_profile.py
@@ -31,14 +31,18 @@ def send_welcome_email(user, profile):
                                                 "pos_url": pos_url,
                                                 "full_name": user_full_name
                                             })
-        
-        frappe.sendmail(
-            recipients=user,
-            subject=email_template.subject,
-            message=message
-        )
-        
-        frappe.msgprint(f"Welcome email sent to <b>{user_full_name}</b> for branch <b>{branch_name}</b>")
+        try:
+            frappe.sendmail(
+                recipients=user,
+                subject=email_template.subject,
+                message=message
+            )
+            frappe.msgprint(f"Welcome email sent to <b>{user_full_name}</b> for branch <b>{branch_name}</b>")
+
+        except Exception as ex:
+            frappe.msgprint(f"Error sending email: {ex}")
+            
+        frappe.response["url"] = f"{pos_url}?{branch_pairing}"
     elif not branch_pairing:
         frappe.throw(f"Unable to get branch pairing link for user <b>{user_full_name}</b> and branch <b>{branch_name}</b>")
     else:


### PR DESCRIPTION
This pull request includes enhancements to the email sending functionality and user feedback mechanisms in the `POS Profile` feature. The most important changes include adding a callback function to handle responses and implementing error handling for email sending.

Enhancements to email sending and user feedback:

* [`metactical/custom_scripts/pos_profile/pos_profile.js`](diffhunk://#diff-75b7d63d6bf216a0b1ea20cbb302180485a3e4fbb2eb45348e39434edd707000R12-R17): Added a callback function to copy the branch pairing link to the clipboard and display an alert when the welcome email is sent.
* [`metactical/custom_scripts/pos_profile/pos_profile.py`](diffhunk://#diff-4a692e595448a657584e42366476e40475f3d18aebfe9ebb87313969276aa239L34-R45): Implemented error handling for the `send_welcome_email` function to catch exceptions and display an error message if email sending fails. Also, added a response URL to the `frappe.response` object.