### PR TITLE
Feature: SB Tag and Copy Labels from Item Group to items

### DIFF
--- a/metactical/custom_scripts/item/item.js
+++ b/metactical/custom_scripts/item/item.js
@@ -97,6 +97,24 @@ frappe.ui.form.on("Item", {
     },
 });
 
+frappe.ui.form.on("MT Item Website Specification", {
+    description: function (frm, cdt, cdn) {
+        var row = locals[cdt][cdn];
+        frappe.call({
+            method: "metactical.custom_scripts.item.item.get_sb_tag",
+            args: {
+                description: row.description,
+                label: row.label,
+            },
+            callback: function (r) {
+                if (r.message) {
+                    frappe.model.set_value(cdt, cdn, "sb_tag", r.message);
+                }
+            },
+        });
+    },
+});
+
 
 function get_descriptions_dict(frm, r) {
     var descriptions = {};

--- a/metactical/custom_scripts/item/item.py
+++ b/metactical/custom_scripts/item/item.py
@@ -107,6 +107,7 @@ def sync_website_specifications(doc):
                     website_spec.label = spec.label
                     website_spec.description = spec.description
                     website_spec.mandatory = spec.mandatory
+                    website_spec.sb_tag = spec.sb_tag
                     website_spec.parent = website_item.name
                     website_spec.parenttype = website_item.doctype
                     website_spec.parentfield = "neb_website_specifications"
@@ -116,6 +117,7 @@ def sync_website_specifications(doc):
                     main_website_spec.label = spec.label
                     main_website_spec.description = spec.description
                     main_website_spec.parent = website_item.name
+                    main_website_spec.sb_tag = spec.sb_tag
                     main_website_spec.parenttype = website_item.doctype
                     main_website_spec.parentfield = "website_specifications"
                     main_website_spec.save()
@@ -148,3 +150,15 @@ def get_website_label_descriptions(label):
         )
     
     frappe.msgprint(desc)
+    
+@frappe.whitelist()
+def get_sb_tag(label, description):
+    sb_tag = frappe.db.get_all(
+        "Website Spec Label Descriptions",
+        filters={"parent": label, "description": description},
+        fields=["sb_tag"]
+    )
+    if sb_tag:
+        return sb_tag[0].sb_tag
+    else:
+        return None

--- a/metactical/custom_scripts/item_group/item_group.js
+++ b/metactical/custom_scripts/item_group/item_group.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+// License: GNU General Public License v3. See license.txt
+
+frappe.ui.form.on("Item Group", {
+    refresh: function (frm) {
+        frm.add_custom_button(__("Copy spec to items"), function () {
+            frappe.confirm('This will add the missing website specification labels to the items. Do you want to continue?',
+                () => {
+                    copy_specs(frm.doc.name);
+                })
+
+		});
+	},
+});
+
+function copy_specs(item_group) {
+    frappe.call({
+        method: "metactical.custom_scripts.item_group.item_group.copy_specifications_to_items",
+        args: {
+            item_group: item_group,
+            add_missing_labels: 1
+        },
+        callback: function (r) {
+            frappe.msgprint("The task has been enqueued as a background job")
+        }
+    });
+}

--- a/metactical/custom_scripts/item_group/item_group.py
+++ b/metactical/custom_scripts/item_group/item_group.py
@@ -80,7 +80,6 @@ def insert_web_specification(item_code, spec):
         'parentfield': 'neb_website_specifications',
         'label': spec.label or '',
         'mandatory': spec.mandatory or 0,
-        'sort_order': spec.sort_order or 0,
         'description': spec.description or ''
     })
     new_spec.insert()

--- a/metactical/custom_scripts/item_group/item_group.py
+++ b/metactical/custom_scripts/item_group/item_group.py
@@ -1,0 +1,121 @@
+import frappe
+from frappe.integrations.doctype.webhook.webhook import enqueue_webhook
+
+
+@frappe.whitelist()
+def copy_specifications_to_items(item_group, add_missing_labels):
+    chunk_size = 2500
+    start = 0
+        
+    # Get a batch of items
+    # Fetch specifications only once per batch
+    web_spec_labels = frappe.get_doc('Item Group', item_group).get('neb_website_specifications')
+    
+    try:
+        items = ['test']
+        while len(items) > 0:
+            items = frappe.get_all(
+                'Item',
+                filters={'item_group': item_group, 'disabled': 0},
+                fields=['name'],
+                limit_start=start,
+                limit_page_length=chunk_size
+            )
+
+            if items:
+                frappe.enqueue(
+                    process_item_specifications,
+                    items=items,
+                    web_spec_labels=web_spec_labels,
+                    queue='long'
+                )
+                
+                start = start + chunk_size
+  
+    except Exception as e:
+        frappe.log_error(title="Error in copy_specifications_to_items", message=frappe.get_traceback())
+        frappe.msgprint(f"Error: {e}")    
+
+def process_item_specifications(items, web_spec_labels):
+    """
+    Process the specifications for a single item.
+    """
+    try:
+        for item in items:
+            item_code = item['name']
+            # Check if the item already has specifications
+            existing_specs = frappe.get_all(
+                'MT Item Website Specification',
+                filters={'parent': item_code},
+                fields=['name', 'label']
+            )
+
+            if existing_specs:
+                existing_labels = [spec['label'] for spec in existing_specs]
+                new_spec_found = False
+                
+                for label in web_spec_labels:
+                    if label.label not in existing_labels:    
+                        new_spec_found = True
+                        insert_web_specification(item_code, label)
+                
+                update_website_items(item_code)
+                frappe.db.commit()
+                continue
+            
+            # Insert new specifications
+            for spec in web_spec_labels:
+                insert_web_specification(item_code, spec)
+            
+            update_website_items(item_code)
+            frappe.db.commit()
+    except Exception as e: 
+        frappe.log_error(title="Error in process_item_specifications", message=frappe.get_traceback())
+            
+def insert_web_specification(item_code, spec):
+    new_spec = frappe.get_doc({
+        'doctype': 'MT Item Website Specification',
+        'parent': item_code,
+        'parenttype': 'Item',
+        'parentfield': 'neb_website_specifications',
+        'label': spec.label or '',
+        'mandatory': spec.mandatory or 0,
+        'sort_order': spec.sort_order or 0,
+        'description': spec.description or ''
+    })
+    new_spec.insert()
+    
+            
+def trigger_item_update(item_code, webhook):
+    if webhook:
+        
+        item = frappe.get_doc('Item', item_code)        
+        enqueue_webhook(item, webhook)
+        
+def update_website_items(item_code):
+    website_items = frappe.get_all("Website Item", filters={"item_code": item_code}, fields=["name"])
+    if website_items:
+        for item in website_items:
+            website_item = frappe.get_doc("Website Item", item.name)
+            website_item.neb_website_specifications = []
+            website_item.website_specifications = []
+            website_item.save()
+            
+            item = frappe.get_doc('Item', item_code)
+            for spec in item.neb_website_specifications:
+                website_spec = frappe.new_doc("MT Item Website Specification")
+                website_spec.label = spec.label
+                website_spec.description = spec.description
+                website_spec.mandatory = spec.mandatory
+                website_spec.parent = website_item.name
+                website_spec.parenttype = website_item.doctype
+                website_spec.parentfield = "neb_website_specifications"
+                website_spec.save(ignore_permissions=True)
+
+                main_website_spec = frappe.new_doc("Item Website Specification")
+                main_website_spec.label = spec.label
+                main_website_spec.description = spec.description
+                main_website_spec.parent = website_item.name
+                main_website_spec.parenttype = website_item.doctype
+                main_website_spec.parentfield = "website_specifications"
+                main_website_spec.save(ignore_permissions=True)

--- a/metactical/custom_scripts/website_item/website_item.py
+++ b/metactical/custom_scripts/website_item/website_item.py
@@ -4,13 +4,13 @@ import json
 
 class CustomWebsiteItem(WebsiteItem):
 	def before_insert(self):
-		website_specs = frappe.db.get_all("MT Item Website Specification", filters={"parent": self.item_code}, fields=["label", "description", "mandatory", "sort_order"])
+		website_specs = frappe.db.get_all("MT Item Website Specification", filters={"parent": self.item_code}, fields=["label", "description", "mandatory", "sb_tag"])
 		for spec in website_specs:
 			website_spec = self.append("neb_website_specifications")
 			website_spec.label = spec.label
 			website_spec.description = spec.description
 			website_spec.mandatory = spec.mandatory
-			website_spec.sort_order = spec.sort_order
+			website_spec.sb_tag = spec.sb_tag
 
 	def validate(self):
 		super().validate()

--- a/metactical/hooks.py
+++ b/metactical/hooks.py
@@ -51,6 +51,7 @@ doctype_js = {
 	"Contact": "custom_scripts/contact/contact.js",
 	"Item": "custom_scripts/item/item.js",
 	"POS Profile": "custom_scripts/pos_profile/pos_profile.js",
+ 	"Item Group": "custom_scripts/item_group/item_group.js"
 }
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 #doctype_list_js = {"doctype" : "public/js/doctype_list.js"}

--- a/metactical/metactical/doctype/mt_item_website_specification/mt_item_website_specification.json
+++ b/metactical/metactical/doctype/mt_item_website_specification/mt_item_website_specification.json
@@ -9,7 +9,8 @@
  "field_order": [
   "label",
   "mandatory",
-  "description"
+  "description",
+  "sb_tag"
  ],
  "fields": [
   {
@@ -50,11 +51,18 @@
    "in_list_view": 1,
    "label": "Mandatory",
    "read_only_depends_on": "eval:parent.doctype != \"Item Group\""
+  },
+  {
+   "fieldname": "sb_tag",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "SB Tag",
+   "options": "SB Tag"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-02-20 11:03:20.694919",
+ "modified": "2025-04-05 01:49:12.637348",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "MT Item Website Specification",

--- a/metactical/metactical/doctype/mt_item_website_specification/mt_item_website_specification.json
+++ b/metactical/metactical/doctype/mt_item_website_specification/mt_item_website_specification.json
@@ -34,16 +34,6 @@
    "read_only_depends_on": "eval:parent.doctype == \"Item Group\";"
   },
   {
-   "depends_on": "eval:parent.doctype != \"Item Group\";",
-   "fetch_from": "description_link.description",
-   "fieldname": "description",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Description",
-   "print_width": "300px",
-   "read_only_depends_on": "eval:parent.doctype == \"Item Group\";"
-  },
-  {
    "columns": 2,
    "default": "0",
    "fieldname": "mandatory",

--- a/metactical/metactical/doctype/sb_tag/sb_tag.js
+++ b/metactical/metactical/doctype/sb_tag/sb_tag.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Techlift Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('SB Tag', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/metactical/metactical/doctype/sb_tag/sb_tag.json
+++ b/metactical/metactical/doctype/sb_tag/sb_tag.json
@@ -1,0 +1,45 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "prompt",
+ "creation": "2025-04-04 02:56:32.333231",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "description",
+   "fieldtype": "Text",
+   "label": "Description"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-04-04 23:27:34.381703",
+ "modified_by": "Administrator",
+ "module": "Metactical",
+ "name": "SB Tag",
+ "naming_rule": "Set by user",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/metactical/metactical/doctype/sb_tag/sb_tag.py
+++ b/metactical/metactical/doctype/sb_tag/sb_tag.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2025, Techlift Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class SBTag(Document):
+	pass

--- a/metactical/metactical/doctype/sb_tag/test_sb_tag.py
+++ b/metactical/metactical/doctype/sb_tag/test_sb_tag.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Techlift Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSBTag(FrappeTestCase):
+	pass

--- a/metactical/metactical/doctype/website_spec_label_descriptions/website_spec_label_descriptions.json
+++ b/metactical/metactical/doctype/website_spec_label_descriptions/website_spec_label_descriptions.json
@@ -7,7 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "description",
-  "sort_order"
+  "sort_order",
+  "sb_tag"
  ],
  "fields": [
   {
@@ -21,12 +22,19 @@
    "fieldtype": "Int",
    "in_list_view": 1,
    "label": "Sort Order"
+  },
+  {
+   "fieldname": "sb_tag",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "SB Tag",
+   "options": "SB Tag"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-20 11:06:33.673492",
+ "modified": "2025-04-07 01:46:15.942140",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Website Spec Label Descriptions",

--- a/metactical/metactical/doctype/website_specification_label/website_specification_label.py
+++ b/metactical/metactical/doctype/website_specification_label/website_specification_label.py
@@ -5,4 +5,6 @@
 from frappe.model.document import Document
 
 class WebsiteSpecificationLabel(Document):
-	pass
+	def validate(self):
+		for row in self.descriptions:
+			row.description = row.description.strip()

--- a/metactical/patches.txt
+++ b/metactical/patches.txt
@@ -14,6 +14,7 @@ execute:frappe.db.sql("CREATE INDEX warehouse on `tabPick List Item` (warehouse)
 execute:frappe.db.sql("UPDATE `tabDocField` SET reqd=0 WHERE fieldname='weight' AND parent='Shipment Parcel Template'")
 metactical.patches.update_source_si_so_last
 metactical.patches.set_default_weight_uom
+metactical.patches.remove_whitespace_from_descriptions
 
 [post_model_sync]
 execute:frappe.db.sql("UPDATE `tabPick List` SET status = 'Picked' WHERE status='Open' AND docstatus='1'")

--- a/metactical/patches/remove_whitespace_from_descriptions.py
+++ b/metactical/patches/remove_whitespace_from_descriptions.py
@@ -1,0 +1,12 @@
+import frappe
+
+def execute():
+    web_spec_descriptions = frappe.get_all("Website Spec Label Descriptions", fields=["name", "description"])
+    for spec in web_spec_descriptions:
+        # Remove leading and trailing whitespace from description
+        cleaned_description = spec.description.strip()
+        
+        # Update the record with the cleaned description
+        frappe.db.set_value("Website Spec Label Descriptions", spec.name, "description", cleaned_description)
+        
+    frappe.db.commit()


### PR DESCRIPTION
This pull request introduces several changes aimed at enhancing the handling of item specifications within the system. The most significant updates include the addition of a new field `sb_tag` to various models, the creation of a new `SB Tag` doctype, and the implementation of a background job for copying specifications to items.

### Addition of `sb_tag` Field:
* [`metactical/custom_scripts/item/item.py`](diffhunk://#diff-74c6ff9a43c3a79ceb884446cfc98b0041760bc7c2930381abfbc634050b2583R110): Added the `sb_tag` field to the `sync_website_specifications` function to ensure the field is properly synced with website specifications. [[1]](diffhunk://#diff-74c6ff9a43c3a79ceb884446cfc98b0041760bc7c2930381abfbc634050b2583R110) [[2]](diffhunk://#diff-74c6ff9a43c3a79ceb884446cfc98b0041760bc7c2930381abfbc634050b2583R120)
* [`metactical/metactical/doctype/mt_item_website_specification/mt_item_website_specification.json`](diffhunk://#diff-075f56e7a9b966e69381e36522bb4d5fe74f922278389eff49988f9fd8cd4001L12-R13): Updated the `MT Item Website Specification` doctype to include the `sb_tag` field. [[1]](diffhunk://#diff-075f56e7a9b966e69381e36522bb4d5fe74f922278389eff49988f9fd8cd4001L12-R13) [[2]](diffhunk://#diff-075f56e7a9b966e69381e36522bb4d5fe74f922278389eff49988f9fd8cd4001R44-R55)
* [`metactical/metactical/doctype/website_spec_label_descriptions/website_spec_label_descriptions.json`](diffhunk://#diff-02be1574880611855bf09803b5d0458d9d20fee9d2f9caa6616035969d440be9R25-R37): Added the `sb_tag` field to the `Website Spec Label Descriptions` doctype.

### New `SB Tag` Doctype:
* [`metactical/metactical/doctype/sb_tag/sb_tag.json`](diffhunk://#diff-505812dc1d00abbc143595b42ce4d91d9d909d88b164f2c98277050360f1a8d3R1-R45): Created a new `SB Tag` doctype to manage SB tags.
* [`metactical/metactical/doctype/sb_tag/sb_tag.py`](diffhunk://#diff-0a27fc7a0a3506892733a5803e8e7f52940fd4477a6b862d95e13ad357896038R1-R8): Added the corresponding Python class for the `SB Tag` doctype.
* [`metactical/metactical/doctype/sb_tag/sb_tag.js`](diffhunk://#diff-c9c9ac1b4017473cbc51b1e3d9af5277a6baa366a95aa334f8599e32a87b6517R1-R8): Added the JavaScript file for the `SB Tag` doctype.
* [`metactical/metactical/doctype/sb_tag/test_sb_tag.py`](diffhunk://#diff-e3f7132267bb795f8a55a86c77e35b6a4fa5b9a49955824bbb6252222abcfbeaR1-R9): Added a test file for the `SB Tag` doctype.

### Background Job for Copying Specifications:
* [`metactical/custom_scripts/item_group/item_group.js`](diffhunk://#diff-c59a89e0fadf4c0372885c0ee31a03fff7575186956067397002c3f77b0c50faR1-R27): Added a custom button to the `Item Group` form to trigger the copying of specifications to items.
* [`metactical/custom_scripts/item_group/item_group.py`](diffhunk://#diff-95afe936c7e10c6f07fd194f4847fdfae3d18a96c63006213da79bd805c6b403R1-R120): Implemented the `copy_specifications_to_items` function to handle the background job for copying specifications.

### Additional Changes:
* [`metactical/patches/remove_whitespace_from_descriptions.py`](diffhunk://#diff-d9f55fe682c84720be9e5ac3000c4dd93b21151b092b4050b05a44e6fa870e1fR1-R12): Added a patch to remove leading and trailing whitespace from descriptions in the `Website Spec Label Descriptions` doctype.
* [`metactical/patches.txt`](diffhunk://#diff-74ae7c63eae5b245a95467ede02f0a65ab8d1fb17809d21efcd254ddf8b4e246R17): Included the new patch for removing whitespace from descriptions.