### PR TITLE
fix: enhance POS data handling to include write-off amount for payment discrepancies

### DIFF
--- a/metactical/custom_scripts/utils/pos_api.py
+++ b/metactical/custom_scripts/utils/pos_api.py
@@ -3,7 +3,7 @@ from metactical.custom_scripts.sales_order.sales_order import make_sales_invoice
 from metactical.custom_scripts.utils.metactical_utils import ( 
 	post_to_rocket_chat, queue_action
 )
-from frappe.utils import file_lock, now_datetime, get_url
+from frappe.utils import file_lock, now_datetime, get_url, flt
 
 @frappe.whitelist()
 def receive_pos_data(*args, **kwargs):
@@ -253,11 +253,22 @@ def create_invoice(sales_order, form_data):
     sales_invoice = make_sales_invoice(sales_order.name)
     sales_invoice.is_pos = 1
     sales_invoice.update_stock = 1
+    sales_invoice.write_off_outstanding_amount_automatically = 0
     sales_invoice.pos_profile = form_data['POSProfile'] + ' Operators'
     frappe.set_user(form_data['SalesPerson'])
     payments = get_payments(form_data)
     sales_invoice.update({'payments': payments})
     sales_invoice.save()
+    
+    # add a write off amount when there is a difference between the total and the payment amount 
+    if sales_invoice.grand_total != form_data['Total']:		
+        write_off_limit = flt(frappe.db.get_value("POS Profile", sales_invoice.pos_profile, "write_off_limit"))
+        difference = sales_invoice.grand_total - form_data['Total']
+        
+        if write_off_limit and difference <= write_off_limit:
+            sales_invoice.write_off_amount = difference
+            sales_invoice.save()
+            frappe.db.commit()
 
     frappe.set_user("Administrator")    
     return sales_invoice


### PR DESCRIPTION
This pull request includes changes to the `metactical/custom_scripts/utils/pos_api.py` file to enhance the handling of sales invoices in the POS system. The most important changes include importing a new utility function, updating the `create_invoice` function to handle write-off amounts, and ensuring the outstanding amount is not automatically written off.

Enhancements to sales invoice handling:

* [`metactical/custom_scripts/utils/pos_api.py`](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baL6-R6): Added import of `flt` from `frappe.utils` to facilitate floating-point operations.
* [`metactical/custom_scripts/utils/pos_api.py`](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baR256-R272): Updated the `create_invoice` function to set `write_off_outstanding_amount_automatically` to `0`, ensuring the outstanding amount is not automatically written off.
* [`metactical/custom_scripts/utils/pos_api.py`](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baR256-R272): Added logic to the `create_invoice` function to handle write-off amounts when there is a difference between the total and the payment amount, considering the write-off limit from the POS profile.