### PR TITLE
fix: update Rocket Chat settings to include POS failed invoices

### DIFF
--- a/metactical/custom_scripts/utils/metactical_utils.py
+++ b/metactical/custom_scripts/utils/metactical_utils.py
@@ -39,7 +39,7 @@ def post_to_rocket_chat(doc, msg, failed=False, rmq=False, pos=False):
 		if not rocket_chat_settings.rocket_notification:
 			return
 
-		channel_name = rocket_chat_settings.channel_name
+		channel_name = rocket_chat_settings.channel_name if not pos else rocket_chat_settings.pos_failed_invoices
 		headers = {
 			'Content-type': rocket_chat_settings.content_type or 'application/json',
 			'X-Auth-Token': rocket_chat_settings.auth_token,

--- a/metactical/custom_scripts/utils/pos_api.py
+++ b/metactical/custom_scripts/utils/pos_api.py
@@ -204,7 +204,28 @@ def submit_sales_order(sales_order, form_data):
         return
     
     if sales_invoice:
-        queue_action(sales_invoice, 'submit')
+        try:
+            frappe.db.commit()
+            sales_invoice.submit()
+            frappe.db.commit()
+        except Exception as e:
+            frappe.db.rollback()
+            frappe.set_user("Administrator")
+            frappe.log_error(title='Submit Invoice Error', message=frappe.get_traceback())
+            
+            # add comment to sales order
+            comment = {"comment_by": form_data['SalesPerson'], "comment": str(e)}
+            create_comment(comment, form_data['SalesPerson'], sales_invoice.name, "Sales Invoice")
+            
+            # post to rocket chat
+            url = "/app/{0}/{1}".format(sales_invoice.doctype.lower().replace(" ", "-"), sales_invoice.name)
+            message = "Unable to submit Invoice created by POS. Please check the document and resubmit. \n[{0}]({1})".format(get_url(url), get_url(url))
+            post_to_rocket_chat(sales_invoice, message, pos=True)
+            
+            # add payment info to sales order
+            add_payment_info_to_sales_order(sales_order, form_data)
+            
+        # queue_action(sales_invoice, 'submit')
         frappe.set_user("Administrator")
 
 def add_payment_info_to_sales_order(sales_order, form_data):
@@ -237,13 +258,13 @@ def create_comments(sales_order, form_data):
     frappe.set_user("Administrator")
     frappe.db.commit()
     
-def create_comment(comment, commentor, sales_order):
+def create_comment(comment, commentor, sales_order, doctype="Sales Order"):
     frappe.get_doc({
         'doctype': 'Comment',
         'comment_email': commentor,
         'comment_by': comment['comment_by'],
         'content': comment['comment'],
-        'reference_doctype': 'Sales Order',
+        'reference_doctype': doctype,
         "comment_type": "Comment",
         'reference_name': sales_order,
     }).save(ignore_permissions=True)

--- a/metactical/metactical/doctype/rocket_chat_settings/rocket_chat_settings.json
+++ b/metactical/metactical/doctype/rocket_chat_settings/rocket_chat_settings.json
@@ -11,7 +11,8 @@
   "content_type",
   "auth_token",
   "user_id",
-  "channel_name"
+  "channel_name",
+  "pos_failed_invoices"
  ],
  "fields": [
   {
@@ -32,7 +33,7 @@
    "fieldname": "channel_name",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Channel Name",
+   "label": "Default Channel Name",
    "reqd": 1
   },
   {
@@ -52,12 +53,17 @@
    "fieldname": "rocket_notification",
    "fieldtype": "Check",
    "label": "Post Error Notification To Rocket Chat"
+  },
+  {
+   "fieldname": "pos_failed_invoices",
+   "fieldtype": "Data",
+   "label": "POS Failed Invoices Channel"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-05-20 07:14:57.818337",
+ "modified": "2025-04-11 04:17:26.359979",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Rocket Chat Settings",
@@ -75,5 +81,6 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }


### PR DESCRIPTION
This pull request includes several changes to improve error handling and notification processes in the `metactical` module, particularly for handling POS failed invoices. The most important changes include modifying the `Rocket Chat` settings, updating the `submit_sales_order` function to handle exceptions, and enhancing the comment creation process.

### Error Handling and Notification Improvements:

* [`metactical/custom_scripts/utils/metactical_utils.py`](diffhunk://#diff-0cdce75a3bf8deb86e6a84508fe544ec6f775a1fb178d74d9d5f132b9ae4ccb8L42-R42): Modified the `post_to_rocket_chat` function to use a different channel name when handling POS failed invoices.
* [`metactical/custom_scripts/utils/pos_api.py`](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baL207-R228): Updated the `submit_sales_order` function to handle exceptions during invoice submission, log errors, post notifications to Rocket Chat, and add comments to the sales order.

### Configuration and Settings Updates:

* [`metactical/metactical/doctype/rocket_chat_settings/rocket_chat_settings.json`](diffhunk://#diff-b79c45b62df3786ef3144c3643ae759885456db197d9088b35eed74f51cab554L14-R15): Added a new field `pos_failed_invoices` to specify a separate channel for POS failed invoices and updated the label for `channel_name` to `Default Channel Name`. [[1]](diffhunk://#diff-b79c45b62df3786ef3144c3643ae759885456db197d9088b35eed74f51cab554L14-R15) [[2]](diffhunk://#diff-b79c45b62df3786ef3144c3643ae759885456db197d9088b35eed74f51cab554L35-R36) [[3]](diffhunk://#diff-b79c45b62df3786ef3144c3643ae759885456db197d9088b35eed74f51cab554R56-R66) [[4]](diffhunk://#diff-b79c45b62df3786ef3144c3643ae759885456db197d9088b35eed74f51cab554L78-R85)

### Comment Creation Enhancements:

* [`metactical/custom_scripts/utils/pos_api.py`](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baL240-R267): Enhanced the `create_comment` function to accept a `doctype` parameter, allowing comments to be associated with different document types.