### PR TITLE
feat: add script to remove web specifications for airsoft items

### DIFF
--- a/metactical/patches.txt
+++ b/metactical/patches.txt
@@ -15,6 +15,7 @@ execute:frappe.db.sql("UPDATE `tabDocField` SET reqd=0 WHERE fieldname='weight' 
 metactical.patches.update_source_si_so_last
 metactical.patches.set_default_weight_uom
 metactical.patches.remove_whitespace_from_descriptions
+metactical.patches.remove_web_specs_for_airsoft_items
 
 [post_model_sync]
 execute:frappe.db.sql("UPDATE `tabPick List` SET status = 'Picked' WHERE status='Open' AND docstatus='1'")

--- a/metactical/patches/remove_web_specs_for_airsoft_items.py
+++ b/metactical/patches/remove_web_specs_for_airsoft_items.py
@@ -1,0 +1,13 @@
+import frappe
+from frappe.utils.fixtures import sync_fixtures
+
+def execute():
+    item_groups = ["Airsoft Pistols", "Airsoft Rifles", "Airsoft Shotguns", "Airsoft SMGs", "Airsoft Sniper Rifles", "Airsoft Revolvers"]
+    for item_group in item_groups:
+        frappe.db.sql("""
+            DELETE `tabMT Item Website Specification` 
+            FROM `tabMT Item Website Specification`
+            JOIN `tabItem` ON `tabItem`.name = `tabMT Item Website Specification`.parent
+            WHERE `tabItem`.item_group = %s AND `tabItem`.disabled = 0
+        """, (item_group,))
+    frappe.db.commit()


### PR DESCRIPTION
A patch to remove all website specs for  "Airsoft Pistols", "Airsoft Rifles", "Airsoft Shotguns", "Airsoft SMGs", "Airsoft Sniper Rifles" and  "Airsoft Revolvers".

The specs were updated using import from excel but there are duplicates in lots of items. This patch will clear out all the specs added to items in the above item groups to start over.