### PR TITLE
Exception handling for RMQ Orders

### DIFF
--- a/metactical/custom_scripts/sales_order/sales_order.py
+++ b/metactical/custom_scripts/sales_order/sales_order.py
@@ -236,26 +236,30 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 
 @frappe.whitelist()
 def get_transaction_key(source, po_no, customer):
-	if not po_no:
-		return
-
-	so_usaepay_transaction = frappe.db.exists("SO USAePay Transaction", {"order_id":po_no, "lead_source": source})
-	if not so_usaepay_transaction:
-		so_usaepay_transaction = frappe.db.exists("SO USAePay Transaction", {"invoice": po_no, "lead_source": source})
-		if not so_usaepay_transaction:
+	try:
+		if not po_no:
 			return
 
-	usaepay_transaction = frappe.db.get_value("SO USAePay Transaction", so_usaepay_transaction, ["transaction_key", "credit_card"], as_dict=True)
+		so_usaepay_transaction = frappe.db.exists("SO USAePay Transaction", {"order_id":po_no, "lead_source": source})
+		if not so_usaepay_transaction:
+			so_usaepay_transaction = frappe.db.exists("SO USAePay Transaction", {"invoice": po_no, "lead_source": source})
+			if not so_usaepay_transaction:
+				return
 
-	obj = {
-		"object": {
-			"key": usaepay_transaction.transaction_key,
-			"creditcard": {
-				"number": usaepay_transaction.credit_card
+		usaepay_transaction = frappe.db.get_value("SO USAePay Transaction", so_usaepay_transaction, ["transaction_key", "credit_card"], as_dict=True)
+
+		obj = {
+			"object": {
+				"key": usaepay_transaction.transaction_key,
+				"creditcard": {
+					"number": usaepay_transaction.credit_card
+				}
 			}
 		}
-	}
-	process_credit_card_tokens(obj, customer)
-	frappe.delete_doc("SO USAePay Transaction", so_usaepay_transaction)
-	
-	return usaepay_transaction.transaction_key
+		process_credit_card_tokens(obj, customer)
+		frappe.delete_doc("SO USAePay Transaction", so_usaepay_transaction)
+
+		return usaepay_transaction.transaction_key
+	except Exception as e:
+		frappe.log_error(title="Error in get_transaction_key", message=frappe.get_traceback())
+		return None

--- a/metactical/custom_scripts/utils/metactical_utils.py
+++ b/metactical/custom_scripts/utils/metactical_utils.py
@@ -140,6 +140,9 @@ def get_usaepay_account(transaction_key=None, merchant_id=None, lead_source=None
 	elif transaction_key:
 		source = frappe.db.get_value("Sales Order", {"neb_usaepay_transaction_key": transaction_key}, "source")
 
+		if not source:
+			source = frappe.db.get_value("SO USAePay Transaction", {"transaction_key": transaction_key}, "lead_source")
+
 		if source:
 			usaepay_account = frappe.db.exists("USAePay Accounts", {"lead_source": source})
 

--- a/metactical/custom_scripts/utils/orders_api.py
+++ b/metactical/custom_scripts/utils/orders_api.py
@@ -6,8 +6,8 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import get_account_det
 
 def receive_rmq_data(parsedContent):
 	try:
-		# from metactical.custom_scripts.utils.loggedinuser import parsedContent
-		
+		# from metactical.custom_scripts.utils.test import parsedContent
+		frappe.log_error(title='RabbitMQ Data Received', message=str(parsedContent))
 		# Assign the shipping province and country based on the parsed content.
 		# If not provided, default to "Alberta" for the province and "Canada" for the country.
 		province = parsedContent['shippingRegion']['name'] if parsedContent.get("shippingRegion") else "Alberta"
@@ -81,7 +81,6 @@ def receive_rmq_data(parsedContent):
 		except Exception as e:
 			frappe.log_error(title='Payment Creation Error', message=frappe.get_traceback())
 			post_to_rocket_chat([], f"Unable to create payment for order {order.name}: {str(e)}", rmq=True)
-   
 	except Exception as e:
 		frappe.log_error(title='RabbitMQ Error', message=frappe.get_traceback())
 		post_to_rocket_chat([], f"Unable to process order from RMQ: {str(e)}", rmq=True)

--- a/metactical/custom_scripts/utils/orders_api.py
+++ b/metactical/custom_scripts/utils/orders_api.py
@@ -68,16 +68,20 @@ def receive_rmq_data(parsedContent):
 		order = create_order(order_detail, customer, parsedContent["PaymentGateway"], shipping_address_doc, billing_address_doc)
 
 		# If the payment gateway is not "interacetransfer", create a payment document with payment details.
-		if parsedContent["PaymentGateway"] != "interacetransfer":
-			if order.neb_usaepay_transaction_key:
-				payment = create_payment(payment_detail, order, company)
-			else:
-				from metactical.custom_scripts.sales_order.sales_order import get_transaction_key
-				transaction_key = get_transaction_key(order.source, order.po_no, order.customer)
-				if transaction_key:
-					frappe.db.set_value("Sales Order", order.name, "neb_usaepay_transaction_key", transaction_key, update_modified=False)
+		try:
+			if parsedContent["PaymentGateway"] != "interacetransfer":
+				if order.neb_usaepay_transaction_key:
 					payment = create_payment(payment_detail, order, company)
-
+				else:
+					from metactical.custom_scripts.sales_order.sales_order import get_transaction_key
+					transaction_key = get_transaction_key(order.source, order.po_no, order.customer)
+					if transaction_key:
+						frappe.db.set_value("Sales Order", order.name, "neb_usaepay_transaction_key", transaction_key, update_modified=False)
+						payment = create_payment(payment_detail, order, company)
+		except Exception as e:
+			frappe.log_error(title='Payment Creation Error', message=frappe.get_traceback())
+			post_to_rocket_chat([], f"Unable to create payment for order {order.name}: {str(e)}", rmq=True)
+   
 	except Exception as e:
 		frappe.log_error(title='RabbitMQ Error', message=frappe.get_traceback())
 		post_to_rocket_chat([], f"Unable to process order from RMQ: {str(e)}", rmq=True)


### PR DESCRIPTION
This pull request introduces error handling improvements across several methods in the `metactical/custom_scripts` module. The changes aim to enhance logging, provide better traceability, and ensure graceful handling of exceptions in critical processes.

### Error Handling Enhancements:

* **`metactical/custom_scripts/sales_order/sales_order.py`:** 
  - Added a `try-except` block in `get_transaction_key` to log errors using `frappe.log_error` and return `None` in case of exceptions. [[1]](diffhunk://#diff-f948eb8116211957bcb67295847afe51ff07d5848258814dcf7dbf45583dd024R239) [[2]](diffhunk://#diff-f948eb8116211957bcb67295847afe51ff07d5848258814dcf7dbf45583dd024R263-R265)

* **`metactical/custom_scripts/utils/orders_api.py`:**
  - Enhanced `receive_rmq_data` to log errors when creating payments fails and notify via Rocket.Chat using `post_to_rocket_chat`. [[1]](diffhunk://#diff-af89c46d2ffe29ae18bfa56356a9997ccc588dd59ea312b688d223c26758dfe1R71) [[2]](diffhunk://#diff-af89c46d2ffe29ae18bfa56356a9997ccc588dd59ea312b688d223c26758dfe1L80-R83)
  - Logged RabbitMQ data received for debugging purposes.

### Data Retrieval Improvements:

* **`metactical/custom_scripts/utils/metactical_utils.py`:**
  - Modified `get_usaepay_account` to retrieve `lead_source` from `SO USAePay Transaction` if `source` is not found in `Sales Order`.