### PR TITLE
Shipping address, Stock entry permission fix

### DIFF
--- a/metactical/custom_scripts/stock_entry/stock_entry.py
+++ b/metactical/custom_scripts/stock_entry/stock_entry.py
@@ -100,10 +100,10 @@ class CustomStockEntry(StockEntry):
 				t_warehouses.append(row.warehouse)
 			
 			for row in self.items:
-				if row.s_warehouse not in s_warehouses:
+				if row.s_warehouse and row.s_warehouse not in s_warehouses:
 					frappe.throw("Warehouse {} not in list of warehouse allowed for user {}".format(row.s_warehouse, frappe.session.user))
 					
-				if row.t_warehouse not in t_warehouses:
+				if row.t_warehouse and row.t_warehouse not in t_warehouses:
 					frappe.throw("Warehouse {} not in list of warehouse allowed for user {}".format(row.t_warehouse, frappe.session.user))
 				
 	def on_submit(self):

--- a/metactical/custom_scripts/usaepay/usaepay_api.py
+++ b/metactical/custom_scripts/usaepay/usaepay_api.py
@@ -162,7 +162,7 @@ def receive_customer_data(response=None, docname=None):
 		doctype = ""
 
 		# check if the trnsaction is initiated from a payment Entry in the ERP
-		if "invoice" in event_body["object"]:
+		if "invoice" in event_body["object"] and event_body["object"]["invoice"]:
 			if event_body["object"]["invoice"]:
 				for doc in docs_to_check:
 					if frappe.db.exists(doc, event_body["object"]["invoice"]):
@@ -190,8 +190,9 @@ def receive_customer_data(response=None, docname=None):
 				return
 
 			sys.stdout.flush()
-			time.sleep(10)
+			time.sleep(15)
 			frappe.db.commit()
+   
 
 			# check if the SO is created by the SB before usaepay webhook response
 			order_exists = frappe.db.sql("SELECT name FROM `tabSales Order` WHERE po_no = %s", (transaction["orderid"],), as_dict=True)
@@ -417,10 +418,12 @@ def get_comment_message(log):
 def create_payment_entry(doc, data, log):
 	try: 
 		mode_of_payment = "Visa"
-		if data["object"]["creditcard"]["category_code"] == "AX":
-			mode_of_payment = "Amex"
-		elif data["object"]["creditcard"]["category_code"] == "M":
-			mode_of_payment = "Master Card"
+		
+		if 'category_code' in data["object"]["creditcard"]:
+			if data["object"]["creditcard"]["category_code"] == "AX":
+				mode_of_payment = "Amex"
+			elif data["object"]["creditcard"]["category_code"] == "M":
+				mode_of_payment = "Master Card"
 
 		pe = get_payment_entry(doc.doctype, doc.name)
 		pe.mode_of_payment = mode_of_payment

--- a/metactical/custom_scripts/utils/orders_api.py
+++ b/metactical/custom_scripts/utils/orders_api.py
@@ -140,18 +140,13 @@ def get_address_and_customer(parsedContent, billing_address_detail, shipping_add
 		customer = get_or_create_customer(parsedContent['publisher_site'], billing_address_detail, shipping_address_detail)
 		billing_address_doc = create_address(billing_address_detail, customer, "Billing")
 
-	# if same address is used for billing and shipping, return the billing address as the shipping address
-	if not parsedContent["PickInLocation"]:
-		shipping_address_doc = billing_address_doc
+	existing_shipping_address = check_existing_address(shipping_address_detail, "Shipping")
+	if existing_shipping_address:
+		# If an existing shipping address is found, fetch its document.
+		shipping_address_doc = frappe.get_doc("Address", existing_shipping_address)
 	else:
-		# if "In store pickup" is selected, create a new address for the shipping address if it does not exist
-		existing_shipping_address = check_existing_address(shipping_address_detail, "Shipping")
-		if existing_shipping_address:
-			# If an existing shipping address is found, fetch its document.
-			shipping_address_doc = frappe.get_doc("Address", existing_shipping_address)
-		else:
-			# If no shipping address is found, create a new one.
-			shipping_address_doc = create_address(shipping_address_detail, customer, "Shipping")
+		# If no shipping address is found, create a new one.
+		shipping_address_doc = create_address(shipping_address_detail, customer, "Shipping")
 
 	# Return the billing address document, shipping address document, and th
 	return billing_address_doc, shipping_address_doc, customer


### PR DESCRIPTION
- Allow users with Stock entry user permission to leave the warehouse fields in the stock entry blank
- Create shipping address for orders that are not  in-store pickup
- Change the delay to add usaepay payment information from 10 to 15 