### PR TITLE
Feature: Get  usaepay transaction detail after order is placed instead of waiting usaepay webhook

### DIFF
--- a/metactical/custom_scripts/sales_order/sales_order.py
+++ b/metactical/custom_scripts/sales_order/sales_order.py
@@ -19,9 +19,6 @@ from metactical.custom_scripts.utils.metactical_utils import (
 	queue_action, 
 	check_si_payment_status_for_so
 )
-from metactical.custom_scripts.usaepay.usaepay_api import (
-	process_credit_card_tokens
-)
 
 class SalesOrderCustom(SalesOrder):
 	def save(self):
@@ -42,9 +39,6 @@ class SalesOrderCustom(SalesOrder):
 		super(SalesOrderCustom, self).validate()
 		self.pull_reserved_qty()
 		
-		if self.po_no and not self.neb_usaepay_transaction_key:
-			self.neb_usaepay_transaction_key = get_transaction_key(self.source, self.po_no, self.customer)
-
 	def pull_reserved_qty(self):
 		for row in self.items:
 			#Check if bin exists
@@ -233,33 +227,3 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 	doclist.set_onload("ignore_price_list", True)
  
 	return doclist
-
-@frappe.whitelist()
-def get_transaction_key(source, po_no, customer):
-	try:
-		if not po_no:
-			return
-
-		so_usaepay_transaction = frappe.db.exists("SO USAePay Transaction", {"order_id":po_no, "lead_source": source})
-		if not so_usaepay_transaction:
-			so_usaepay_transaction = frappe.db.exists("SO USAePay Transaction", {"invoice": po_no, "lead_source": source})
-			if not so_usaepay_transaction:
-				return
-
-		usaepay_transaction = frappe.db.get_value("SO USAePay Transaction", so_usaepay_transaction, ["transaction_key", "credit_card"], as_dict=True)
-
-		obj = {
-			"object": {
-				"key": usaepay_transaction.transaction_key,
-				"creditcard": {
-					"number": usaepay_transaction.credit_card
-				}
-			}
-		}
-		process_credit_card_tokens(obj, customer)
-		frappe.delete_doc("SO USAePay Transaction", so_usaepay_transaction)
-
-		return usaepay_transaction.transaction_key
-	except Exception as e:
-		frappe.log_error(title="Error in get_transaction_key", message=frappe.get_traceback())
-		return None

--- a/metactical/custom_scripts/usaepay/usaepay_api.py
+++ b/metactical/custom_scripts/usaepay/usaepay_api.py
@@ -896,7 +896,7 @@ def process_missed_usaepay_transactions():
 		if order and order.advance_paid == 0:
 			try:
 				frappe.enqueue(get_usaepay_order_detail, 
-							   so_transaction=so_transaction, 
+							   transaction=so_transaction, 
 							   order=order, 
 							   queue='long', 
 							   timeout=600, 

--- a/metactical/custom_scripts/usaepay/usaepay_api.py
+++ b/metactical/custom_scripts/usaepay/usaepay_api.py
@@ -33,12 +33,12 @@ def get_transaction_from_usaepay(usaepay_transaction_key, headers, merchant_id=N
 	if response.status_code == 200:
 		transaction = json.loads(response.text)
 		if transaction.get("error"):
-			frappe.throw(_("Failed to fetch transaction details from USAePay: {0}").format(cstr(transaction.get("error"))))
-
+			# frappe.throw(_("Failed to fetch transaction details from USAePay: {0}").format(cstr(transaction.get("error"))))
+			frappe.throw(_("{0} - Failed to fetch transaction details from USAePay - {1}").format(usaepay_transaction_key, cstr(transaction.get("error"))))
 		return transaction
 	else:
 		response = json.loads(response.text)
-		frappe.throw(_("Failed to fetch transaction details from USAePay: {0}").format(response.get("error")))
+		frappe.throw(_("{0} - Failed to fetch transaction details from USAePay: {1}").format(usaepay_transaction_key, response.get("error")))
 	
 	return None
 
@@ -170,52 +170,7 @@ def receive_customer_data(response=None, docname=None):
 						break
 			else:
 				return
-		# when the payment is created from the website and the SO is not created yet
-		# webhook's response will be added to a temporary doc and then will be processed when the SO is created.
-		# This is to avoid the case where the webhook response comes before the SO is created in the ERP
-		else:
-			usaepay_account = get_usaepay_account(merchant_id=event_body["merchant"]["merch_key"])
-			if not usaepay_account:
-				return
-			
-			token_hash = get_token_hash(usaepay_account)
-			headers = {
-				"Content-Type": "application/json",
-				"Authorization": token_hash
-			}
 
-			transaction = event_body["object"]["key"]
-			transaction = get_transaction_from_usaepay(transaction, headers, event_body["merchant"]["merch_key"])
-			if not transaction or "orderid" not in transaction:
-				return
-
-			sys.stdout.flush()
-			time.sleep(15)
-			frappe.db.commit()
-   
-
-			# check if the SO is created by the SB before usaepay webhook response
-			order_exists = frappe.db.sql("SELECT name FROM `tabSales Order` WHERE po_no = %s", (transaction["orderid"],), as_dict=True)
-			if len(order_exists) > 0:
-				event_body["object"] = transaction
-				doctype = "Sales Order"
-			else:
-				existing_transaction = frappe.db.exists("SO USAePay Transaction", {"order_id": transaction["orderid"], "merchant_id": event_body["merchant"]["merch_key"]})
-				if "creditcard" in transaction and not existing_transaction:
-					lead_source = usaepay_account.lead_source
-					frappe.get_doc({
-						"doctype": "SO USAePay Transaction", 
-						"order_id": transaction["orderid"],
-						"invoice": transaction["invoice"],
-						"credit_card": transaction["creditcard"]["number"],
-						"transaction_key": transaction["key"],
-						"merchant_id": event_body["merchant"]["merch_key"],
-						"lead_source": lead_source,
-						"payload": response
-					}).insert()
-					frappe.db.commit()
-					return
-		
 		# doctype = the doctype referenced in the Payment Entry or the Sales order created by the SB
 		if not doctype:
 			return
@@ -249,23 +204,33 @@ def receive_customer_data(response=None, docname=None):
 		except Exception as e:
 			frappe.log_error(title="USAePay Log Update Error", message=frappe.get_traceback())	
 
-		if docname:
-			update_usaepay_transaction(docname)
 	except frappe.ValidationError as e:
-		if docname:
-			update_usaepay_transaction(docname)
-		else:
-			frappe.db.commit()
+		frappe.db.commit()
 	except Exception as e:
 		frappe.log_error(title="USAePay Log Update Error", message=frappe.get_traceback())
-		if docname:
-			update_usaepay_transaction(docname)
 
-def update_usaepay_transaction(docname):    
-	if docname and frappe.db.exists("SO USAePay Transaction", docname):
-		frappe.db.set_value("SO USAePay Transaction", docname, "processed_again", 1)
+def get_usaepay_order_detail(transaction, order):
+	usaepay_account = get_usaepay_account(lead_source=order.source)
+	if not usaepay_account:
+		frappe.throw(_("USAePay account not found for the lead source {0}").format(order.source))
+		
+	headers, usaepay_url = get_headers(lead_source=order.source)
+	if not usaepay_url:
+		frappe.log_error(title="USAePay URL not set", message="USAePay URL is not set in Metactical Settings for the lead source {0}".format(order.source))
+
+	if not transaction["authorizeTransactionId"]:
+		return 
+
+	transaction = get_transaction_from_usaepay(transaction["authorizeTransactionId"], headers, usaepay_account.get("merchant_id"))
+	event_body = {}
+	event_body["object"] = frappe._dict(transaction)
+
+	# create payment entry if the transaction is successful
+	process_sales_order(event_body, transaction["key"])
+	so_usaepay_transaction = frappe.db.get_value("SO USAePay Transaction", {"order_id": order.name}, "name")
+	if so_usaepay_transaction:
+		frappe.delete_doc("SO USAePay Transaction", so_usaepay_transaction)
 		frappe.db.commit()
-
 
 def process_sales_order(event_body, transaction_key):
 	sales_order = frappe.db.get_value("Sales Order", {"po_no": event_body["object"]["invoice"]}, ["name", "customer", "neb_usaepay_transaction_key", "po_no", "company", "source"], as_dict=1)
@@ -922,9 +887,24 @@ def get_lead_source(transaction_key):
 
 def process_missed_usaepay_transactions():
 	# Get all USAePay transactions that are not linked to any Sales Order or Payment Entry
-	usaepay_transactions = frappe.get_all("SO USAePay Transaction", filters={"processed_again": 0, "payload": ["is", "set"]}, fields=["name", "payload"])
-
+	usaepay_transactions = frappe.get_all("SO USAePay Transaction", fields=["name", "transaction_key", "order_id"])
 	for transaction in usaepay_transactions:
 		# convert payload to dict
-		payload = json.loads(transaction.payload)
-		frappe.enqueue(receive_customer_data, job_name="Processing usaepay data", response=payload, queue='long', timeout=600)	
+		order = frappe.get_doc("Sales Order", transaction.order_id)
+		so_transaction = {"authorizeTransactionId": transaction.transaction_key}
+
+		if order and order.advance_paid == 0:
+			try:
+				frappe.enqueue(get_usaepay_order_detail, 
+							   so_transaction=so_transaction, 
+							   order=order, 
+							   queue='long', 
+							   timeout=600, 
+							   event='get_usaepay_order_detail')
+			except Exception as e:
+				frappe.log_error(title="USAePay Order Detail Fetch Error", message=frappe.get_traceback())
+		else:
+			if order.advance_paid > 0:
+				frappe.delete_doc("SO USAePay Transaction", transaction["name"])
+			else:
+				frappe.log_error(title="USAePay Order Not Found", message="Sales Order not found for transaction {0}".format(transaction["transaction_key"]))

--- a/metactical/custom_scripts/utils/metactical_utils.py
+++ b/metactical/custom_scripts/utils/metactical_utils.py
@@ -459,13 +459,17 @@ def remove_tz_from_date(date):
 	# Truncate to six digits
 	# '%Y-%m-%dT%H:%M:%S.%fZ'  check if the date has this format
 	# if not, add the missing part
+ 
 	date_str_fixed = date
 	if len(date) == 19:
 		date_str_fixed = date + ".000000Z"
 	elif len(date) > 26:
 		date_str_fixed = date[:26] + "Z"
 	elif len(date) > 19 and len(date) < 26:
-		date_str_fixed = date + "0" * (26 - len(date)) + "Z"
+		if date[-1] == "Z":
+			date_str_fixed = date
+		else:
+			date_str_fixed = date + "0" * (26 - len(date)) + "Z"
 
 	parsed_date = datetime.strptime(date_str_fixed, "%Y-%m-%dT%H:%M:%S.%fZ")
 

--- a/metactical/custom_scripts/utils/orders_api.py
+++ b/metactical/custom_scripts/utils/orders_api.py
@@ -89,11 +89,7 @@ def receive_rmq_data(parsedContent):
 				if order.neb_usaepay_transaction_key or succesfull_transaction['paymentGatewayAlias'] == 'paypalexpress':
 					payment = create_payment(payment_detail, order, company)
 				else:
-					from metactical.custom_scripts.sales_order.sales_order import get_transaction_key
-					transaction_key = get_transaction_key(order.source, order.po_no, order.customer)
-					if transaction_key:
-						frappe.db.set_value("Sales Order", order.name, "neb_usaepay_transaction_key", transaction_key, update_modified=False)
-						payment = create_payment(payment_detail, order, company)
+					process_payment_entry(succesfull_transaction, order)
       
 			elif succesfull_transaction["paymentGatewayAlias"] == "interacetransfer":
 				add_tag(order, "EtransferPaymentPending")
@@ -106,6 +102,22 @@ def receive_rmq_data(parsedContent):
 		frappe.log_error(title='RabbitMQ Error', message=frappe.get_traceback())
 		post_to_rocket_chat([], f"Unable to process order from RMQ: {str(e)}", rmq=True)
 
+def process_payment_entry(transaction, order):
+    from metactical.custom_scripts.usaepay.usaepay_api import get_usaepay_order_detail
+    
+    # Hold the transaction information
+    frappe.get_doc({
+		"doctype": "SO USAePay Transaction", 
+		"order_id": order.name,
+		"po_no": order.po_no,
+		"transaction_key": transaction["authorizeTransactionId"],
+		"lead_source": order.source,
+	}).insert()
+    frappe.db.commit()
+    
+    # get transaction details from USAePay and create payment entry
+    get_usaepay_order_detail(transaction, order)
+    
 def add_tag(order, tag):
 	if frappe.db.exists("Tag", tag):
 		try:

--- a/metactical/metactical/doctype/so_usaepay_transaction/so_usaepay_transaction.json
+++ b/metactical/metactical/doctype/so_usaepay_transaction/so_usaepay_transaction.json
@@ -7,24 +7,16 @@
  "engine": "InnoDB",
  "field_order": [
   "order_id",
-  "invoice",
+  "po_no",
   "credit_card",
   "transaction_key",
-  "merchant_id",
-  "lead_source",
-  "processed_again",
-  "payload"
+  "lead_source"
  ],
  "fields": [
   {
    "fieldname": "order_id",
    "fieldtype": "Data",
    "label": "Order ID"
-  },
-  {
-   "fieldname": "invoice",
-   "fieldtype": "Data",
-   "label": "Invoice"
   },
   {
    "fieldname": "credit_card",
@@ -38,32 +30,20 @@
    "label": "Transaction Key"
   },
   {
-   "fieldname": "merchant_id",
-   "fieldtype": "Data",
-   "label": "Merchant ID"
-  },
-  {
    "fieldname": "lead_source",
    "fieldtype": "Link",
    "label": "Lead Source",
    "options": "Lead Source"
   },
   {
-   "default": "0",
-   "fieldname": "processed_again",
-   "fieldtype": "Check",
-   "label": "Processed Again?"
-  },
-  {
-   "fieldname": "payload",
-   "fieldtype": "JSON",
-   "label": "Payload",
-   "read_only": 1
+   "fieldname": "po_no",
+   "fieldtype": "Data",
+   "label": "Customer's Purchase Order - Website Order No"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-14 04:09:35.392532",
+ "modified": "2025-07-27 06:34:36.997766",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "SO USAePay Transaction",


### PR DESCRIPTION
This pull request removes unused functionality related to USAePay transaction handling, simplifies the codebase, and introduces a more streamlined approach for processing payments and transactions. The key changes include removing redundant methods, refactoring transaction handling logic, and updating the `SO USAePay Transaction` doctype structure.

### Removal of unused functionality:
* Removed the `get_transaction_key` method and its associated logic, which was no longer in use (`sales_order.py`, `usaepay_api.py`, `orders_api.py`). [[1]](diffhunk://#diff-f948eb8116211957bcb67295847afe51ff07d5848258814dcf7dbf45583dd024L236-L265) [[2]](diffhunk://#diff-970cdae7ebfd6fb544b532f7cc80180a2dc47056d52cef422fb408164c204b44L173-L217) [[3]](diffhunk://#diff-af89c46d2ffe29ae18bfa56356a9997ccc588dd59ea312b688d223c26758dfe1L92-R92)
* Deleted webhook handling logic for temporary transaction storage when sales orders are not yet created (`usaepay_api.py`).

### Refactoring of transaction handling:
* Introduced a new `process_payment_entry` method to handle USAePay transactions more efficiently, replacing older logic (`orders_api.py`).
* Added `get_usaepay_order_detail` to fetch transaction details and process sales orders directly (`usaepay_api.py`).

### Updates to `SO USAePay Transaction` doctype:
* Removed unused fields like `merchant_id`, `processed_again`, and `payload`, and replaced the `invoice` field with `po_no` to better align with current requirements (`so_usaepay_transaction.json`). [[1]](diffhunk://#diff-00e871e1ef67e4b70e587163c649ebc6418989dec78a581939c6aa4b96cd82c3L10-L28) [[2]](diffhunk://#diff-00e871e1ef67e4b70e587163c649ebc6418989dec78a581939c6aa4b96cd82c3L40-R46)

### Improved error handling:
* Enhanced error messages in `get_transaction_from_usaepay` to include the transaction key for better traceability (`usaepay_api.py`).

### Minor fixes:
* Adjusted date parsing logic in `remove_tz_from_date` to handle edge cases more robustly (`metactical_utils.py`).