### PR TITLE
Pick List Adjustment

### DIFF
--- a/metactical/custom_scripts/pick_list/pick_list.js
+++ b/metactical/custom_scripts/pick_list/pick_list.js
@@ -16,6 +16,71 @@ frappe.ui.form.on('Pick List', {
 		dashboard_pick_list_doctype(frm, "Sales Order");
 
 	},
+
+	before_save: async function(frm) {
+		// validate if items table is not empty
+		if (frm.doc.locations.length == 0) {
+			frappe.throw(__("Please add items to the Pick List before saving."));
+		}
+
+		// validate if the reference sales order has a shipping address
+		let sales_orders = frm.doc.locations.map(location => location.sales_order);
+
+		if (sales_orders.length > 0) {
+			// remove duplicates
+			sales_orders = [...new Set(sales_orders)];
+
+			for (const sales_order of sales_orders) {
+				let r = await frappe.call({
+					'method': 'frappe.client.get',
+					'args': {
+						'doctype': 'Sales Order',
+						'name': sales_order
+					}
+				});
+
+				if (!r.exc) {
+					if (!r.message.shipping_address_name) {
+						frappe.throw(__("Please make sure all referenced Sales Orders have a Shipping Address before saving the Pick List. Sales Order {0} does not have a Shipping Address.", [sales_order]));
+					}
+				}
+			}
+		}
+
+		// Validating there is no duplicated items
+		var item_list = [];
+		var duplicated = false;
+		var duplicated_item = [];
+		for (const row of frm.doc.locations) {
+			let result = await frappe.call({
+				'method': 'metactical.custom_scripts.sales_order.sales_order.get_product_bundle_items',
+				'args': { 'item_code': row.item_code }
+			});
+
+			if (result.message && result.message.length > 0) {
+				let product_bundle_items = result.message;
+				for (const pb_item of product_bundle_items) {
+					if (item_list.includes(pb_item.item_code)) {
+						duplicated = true;
+						duplicated_item.push(pb_item.item_code);
+					}
+					item_list.push(pb_item.item_code);
+				}
+			}
+
+			if (item_list.includes(row.item_code)) {
+				duplicated = true;
+				duplicated_item.push(row.item_code);
+			}
+
+			item_list.push(row.item_code);
+		}
+
+		if (duplicated) {
+			duplicated_item = [...new Set(duplicated_item)];
+			frappe.throw(__("Item(s) " + duplicated_item.join(", ") + " are duplicated. Please remove the duplicate before proceeding to create Pick List."));
+		}
+	},
 	
 	on_submit: function(frm){	
 		setTimeout(function(){

--- a/metactical/custom_scripts/pick_list/pick_list.js
+++ b/metactical/custom_scripts/pick_list/pick_list.js
@@ -16,71 +16,6 @@ frappe.ui.form.on('Pick List', {
 		dashboard_pick_list_doctype(frm, "Sales Order");
 
 	},
-
-	before_save: async function(frm) {
-		// validate if items table is not empty
-		if (frm.doc.locations.length == 0) {
-			frappe.throw(__("Please add items to the Pick List before saving."));
-		}
-
-		// validate if the reference sales order has a shipping address
-		let sales_orders = frm.doc.locations.map(location => location.sales_order);
-
-		if (sales_orders.length > 0) {
-			// remove duplicates
-			sales_orders = [...new Set(sales_orders)];
-
-			for (const sales_order of sales_orders) {
-				let r = await frappe.call({
-					'method': 'frappe.client.get',
-					'args': {
-						'doctype': 'Sales Order',
-						'name': sales_order
-					}
-				});
-
-				if (!r.exc) {
-					if (!r.message.shipping_address_name) {
-						frappe.throw(__("Please make sure all referenced Sales Orders have a Shipping Address before saving the Pick List. Sales Order {0} does not have a Shipping Address.", [sales_order]));
-					}
-				}
-			}
-		}
-
-		// Validating there is no duplicated items
-		var item_list = [];
-		var duplicated = false;
-		var duplicated_item = [];
-		for (const row of frm.doc.locations) {
-			let result = await frappe.call({
-				'method': 'metactical.custom_scripts.sales_order.sales_order.get_product_bundle_items',
-				'args': { 'item_code': row.item_code }
-			});
-
-			if (result.message && result.message.length > 0) {
-				let product_bundle_items = result.message;
-				for (const pb_item of product_bundle_items) {
-					if (item_list.includes(pb_item.item_code)) {
-						duplicated = true;
-						duplicated_item.push(pb_item.item_code);
-					}
-					item_list.push(pb_item.item_code);
-				}
-			}
-
-			if (item_list.includes(row.item_code)) {
-				duplicated = true;
-				duplicated_item.push(row.item_code);
-			}
-
-			item_list.push(row.item_code);
-		}
-
-		if (duplicated) {
-			duplicated_item = [...new Set(duplicated_item)];
-			frappe.throw(__("Item(s) " + duplicated_item.join(", ") + " are duplicated. Please remove the duplicate before proceeding to create Pick List."));
-		}
-	},
 	
 	on_submit: function(frm){	
 		setTimeout(function(){
@@ -154,4 +89,3 @@ frappe.templates["dashboard_pick_list_doctype"] = ' \
     	<span class="text-muted small count"></span> \
     	<span class="open-notification hidden" title="{{ __("Open {0}", [__(doctype)])}}"></span> \
     	</div>';
-

--- a/metactical/custom_scripts/pick_list/pick_list.js
+++ b/metactical/custom_scripts/pick_list/pick_list.js
@@ -1,5 +1,8 @@
 frappe.ui.form.on('Pick List', {
 	refresh: function(frm){
+		// Remove Get Items button
+		frm.remove_custom_button("Get Items"); 
+
 		//Code for custom cancel button that saves cancel reason first
 		if(frm.doc.docstatus == 1){
 			frm.page.clear_secondary_action();
@@ -49,6 +52,29 @@ frappe.ui.form.on('Pick List', {
 		)
 	},
 
+	add_get_items_button: (frm) => {
+		let purpose = frm.doc.purpose;
+		if (purpose != "Delivery" || frm.doc.docstatus !== 0) return;
+		let get_query_filters = {
+			docstatus: 1,
+			per_delivered: ["<", 100],
+			status: ["!=", ""],
+			customer: frm.doc.customer,
+		};
+		frm.get_items_btn = frm.add_custom_button(__("Get Items"), () => {
+			erpnext.utils.map_current_doc({
+				method: "metactical.custom_scripts.pick_list.pick_list.create_pick_list",
+				source_doctype: "Sales Order",
+				target: frm,
+				setters: {
+					company: frm.doc.company,
+					customer: frm.doc.customer,
+				},
+				date_field: "transaction_date",
+				get_query_filters: get_query_filters,
+			});
+		});
+	},
 });
 
 

--- a/metactical/custom_scripts/pick_list/pick_list.py
+++ b/metactical/custom_scripts/pick_list/pick_list.py
@@ -48,7 +48,6 @@ class CustomPickList(PickList):
   
 	def validate_sales_order_shipping_address(self):
 		sales_orders = [d.sales_order for d in self.locations if d.sales_order]
-		frappe.msgprint(_("Validating shipping address..."))
 		sales_orders = set(sales_orders)
 		for so in sales_orders:
 			so_doc = frappe.get_doc("Sales Order", so)
@@ -71,7 +70,7 @@ class CustomPickList(PickList):
 
 		if duplicated_items:
 			duplicated_items = set(duplicated_items)
-			frappe.throw(_("Sales Order {0} has duplicated items: {1}. Please remove the duplicated items.").format(so, ", ".join(duplicated_items)))
+			frappe.throw(_("Sales Order {0} contains duplicate items: {1}. Please remove the duplicates.").format(so, ", ".join(duplicated_items)))
 
 	def update_sales_order_item(self, item, picked_qty, item_code):
 		item_table = "Sales Order Item" if not item.product_bundle_item else "Packed Item"

--- a/metactical/custom_scripts/pick_list/pick_list.py
+++ b/metactical/custom_scripts/pick_list/pick_list.py
@@ -39,6 +39,65 @@ class CustomPickList(PickList):
 			queue_action(self, "submit", timeout=2000)
 		else:
 			super().save()
+			
+	def validate(self):
+		# super(CustomPickList, self).validate()
+		self.check_for_existing_draft()
+		self.validate_sales_order_shipping_address()
+		self.validate_duplicated_items()
+  
+	def validate_sales_order_shipping_address(self):
+		sales_orders = [d.sales_order for d in self.locations if d.sales_order]
+		frappe.msgprint(_("Validating shipping address..."))
+		sales_orders = set(sales_orders)
+		for so in sales_orders:
+			so_doc = frappe.get_doc("Sales Order", so)
+			if not so_doc.shipping_address_name:
+				frappe.throw(_("Please set a shipping address in Sales Order {0}").format(so))
+
+
+	def validate_duplicated_items(self):
+		item_list = []
+		duplicated_items = []
+		sales_orders = [d.sales_order for d in self.locations if d.sales_order]
+		sales_orders = set(sales_orders)
+		for so in sales_orders:
+			sales_order = frappe.get_doc("Sales Order", so)
+			for item in sales_order.items:
+				if item.item_code in item_list:
+					duplicated_items.append(item.item_code)
+				else:
+					item_list.append(item.item_code)
+
+		if duplicated_items:
+			duplicated_items = set(duplicated_items)
+			frappe.throw(_("Sales Order {0} has duplicated items: {1}. Please remove the duplicated items.").format(so, ", ".join(duplicated_items)))
+
+	def update_sales_order_item(self, item, picked_qty, item_code):
+		item_table = "Sales Order Item" if not item.product_bundle_item else "Packed Item"
+		stock_qty_field = "stock_qty" if not item.product_bundle_item else "qty"
+		
+		# Metactical Customization: Take into consideration returned qty
+		already_picked, actual_qty, returned_qty = frappe.db.get_value(
+			item_table,
+			item.sales_order_item,
+			["picked_qty", stock_qty_field, "returned_qty"],
+		)
+		
+		if returned_qty is None:
+			returned_qty = 0
+
+		if self.docstatus == 1:
+			if (((already_picked + picked_qty - returned_qty) / actual_qty) * 100) > (
+				100 + flt(frappe.db.get_single_value("Stock Settings", "over_delivery_receipt_allowance"))
+			):
+				frappe.throw(
+					_(
+						"You are picking more than required quantity for {}. Check if there is any other pick list created for {}"
+					).format(item_code, item.sales_order)
+				)
+
+		frappe.db.set_value(item_table, item.sales_order_item, "picked_qty", already_picked + picked_qty)
 
 	def before_save(self):
 		super(CustomPickList, self).before_save()

--- a/metactical/custom_scripts/pick_list/pick_list.py
+++ b/metactical/custom_scripts/pick_list/pick_list.py
@@ -72,32 +72,6 @@ class CustomPickList(PickList):
 			duplicated_items = set(duplicated_items)
 			frappe.throw(_("Sales Order {0} contains duplicate items: {1}. Please remove the duplicates.").format(so, ", ".join(duplicated_items)))
 
-	def update_sales_order_item(self, item, picked_qty, item_code):
-		item_table = "Sales Order Item" if not item.product_bundle_item else "Packed Item"
-		stock_qty_field = "stock_qty" if not item.product_bundle_item else "qty"
-		
-		# Metactical Customization: Take into consideration returned qty
-		already_picked, actual_qty, returned_qty = frappe.db.get_value(
-			item_table,
-			item.sales_order_item,
-			["picked_qty", stock_qty_field, "returned_qty"],
-		)
-		
-		if returned_qty is None:
-			returned_qty = 0
-
-		if self.docstatus == 1:
-			if (((already_picked + picked_qty - returned_qty) / actual_qty) * 100) > (
-				100 + flt(frappe.db.get_single_value("Stock Settings", "over_delivery_receipt_allowance"))
-			):
-				frappe.throw(
-					_(
-						"You are picking more than required quantity for {}. Check if there is any other pick list created for {}"
-					).format(item_code, item.sales_order)
-				)
-
-		frappe.db.set_value(item_table, item.sales_order_item, "picked_qty", already_picked + picked_qty)
-
 	def before_save(self):
 		super(CustomPickList, self).before_save()
 

--- a/metactical/custom_scripts/pick_list/pick_list.py
+++ b/metactical/custom_scripts/pick_list/pick_list.py
@@ -42,7 +42,6 @@ class CustomPickList(PickList):
 			
 	def validate(self):
 		super(CustomPickList, self).validate()
-		self.check_for_existing_draft()
 		self.validate_sales_order_shipping_address()
 		self.validate_duplicated_items()
   

--- a/metactical/custom_scripts/pick_list/pick_list.py
+++ b/metactical/custom_scripts/pick_list/pick_list.py
@@ -41,7 +41,7 @@ class CustomPickList(PickList):
 			super().save()
 			
 	def validate(self):
-		# super(CustomPickList, self).validate()
+		super(CustomPickList, self).validate()
 		self.check_for_existing_draft()
 		self.validate_sales_order_shipping_address()
 		self.validate_duplicated_items()

--- a/metactical/custom_scripts/pick_list/pick_list.py
+++ b/metactical/custom_scripts/pick_list/pick_list.py
@@ -58,13 +58,13 @@ class CustomPickList(PickList):
 		if len(self.locations) > 0:
 			if self.locations[0].get('sales_order'):
 				rv = BytesIO()
-				_barcode.get('code128', self.locations[0].sales_order).write(rv, {"module_width":0.4})
+				# _barcode.get('code128', self.locations[0].sales_order).write(rv, {"module_width":0.4})
 				bstring = rv.getvalue()
 				self.barcode = bstring.decode('ISO-8859-1')
 				
 				# STO Barcode
 				sv = BytesIO()
-				_barcode.get('code128', self.name).write(sv, {"module_width":0.4})
+				# _barcode.get('code128', self.name).write(sv, {"module_width":0.4})
 				stoBarcode = sv.getvalue()
 				self.sal_sto_barcode = stoBarcode.decode('ISO-8859-1')
 

--- a/metactical/custom_scripts/pick_list/pick_list.py
+++ b/metactical/custom_scripts/pick_list/pick_list.py
@@ -117,13 +117,13 @@ class CustomPickList(PickList):
 		if len(self.locations) > 0:
 			if self.locations[0].get('sales_order'):
 				rv = BytesIO()
-				# _barcode.get('code128', self.locations[0].sales_order).write(rv, {"module_width":0.4})
+				_barcode.get('code128', self.locations[0].sales_order).write(rv, {"module_width":0.4})
 				bstring = rv.getvalue()
 				self.barcode = bstring.decode('ISO-8859-1')
 				
 				# STO Barcode
 				sv = BytesIO()
-				# _barcode.get('code128', self.name).write(sv, {"module_width":0.4})
+				_barcode.get('code128', self.name).write(sv, {"module_width":0.4})
 				stoBarcode = sv.getvalue()
 				self.sal_sto_barcode = stoBarcode.decode('ISO-8859-1')
 

--- a/metactical/custom_scripts/sales_order/sales_order.js
+++ b/metactical/custom_scripts/sales_order/sales_order.js
@@ -20,7 +20,7 @@ frappe.ui.form.on('Sales Order', {
 			
 			frm.remove_custom_button("Pick List", 'Create'); 
 			frm.add_custom_button(__('Pick List'), () => frm.events.create_pick_list_custom(frm), __("Create"));
-			frm.remove_custom_button("Work Order", 'Create');
+			// frm.remove_custom_button("Work Order", 'Create');
 			frm.remove_custom_button("Request for Raw Materials", 'Create'); 
 			frm.remove_custom_button("Project", 'Create'); 
 			frm.remove_custom_button("Subscription", 'Create'); 

--- a/metactical/custom_scripts/sales_order/sales_order.js
+++ b/metactical/custom_scripts/sales_order/sales_order.js
@@ -183,42 +183,46 @@ frappe.ui.form.on('Sales Order', {
 		dialog.show();
 	},
 	
-	create_pick_list_custom: function(frm) {
-		// validating shipping address name is selected
+	create_pick_list_custom: async function(frm) {
+		// validating shipping address name
 		if (!frm.doc.shipping_address_name) {
 			frappe.throw(__("Please select Shipping Address Name before proceeding to create Pick List."));
 		}
 
 		// Validating there is no duplicated items
 		var item_list = [];
-		cur_frm.doc.items.forEach(function(row) {
-			frappe.call({
+		var duplicated = false;
+		var duplicated_item = [];
+		for (const row of cur_frm.doc.items) {
+			let result = await frappe.call({
 				'method': 'metactical.custom_scripts.sales_order.sales_order.get_product_bundle_items',
-				'args': {
-					'item_code': row.item_code
-				},
-				'callback': function(result) {
-					if (result.message.length > 0) {
-						console.log("Product Bundle Items: ", result.message);
-						var product_bundle_items = result.message;
-						product_bundle_items.forEach(function(pb_item) {
-							if (item_list.includes(pb_item.item_code)) {
-								console.log("Duplicated Item in Product Bundle: ", pb_item.item_code);
-								console.log("Item List: ", item_list);
-								frappe.throw(__("Item " + pb_item.item_code + " is duplicated from the product bundle. Please remove the duplicate before proceeding to create Pick List."));
-							}
-							item_list.push(pb_item.item_code);
-						});
-					}
-				}
+				'args': { 'item_code': row.item_code }
 			});
+
+			if (result.message && result.message.length > 0) {
+				let product_bundle_items = result.message;
+				for (const pb_item of product_bundle_items) {
+					if (item_list.includes(pb_item.item_code)) {
+						duplicated = true;
+						duplicated_item.push(pb_item.item_code);
+					}
+					item_list.push(pb_item.item_code);
+				}
+			}
+
 			if (item_list.includes(row.item_code)) {
-				frappe.throw(__("Item " + row.item_code + " is duplicated. Please remove the duplicate before proceeding to create Pick List."));
+				duplicated = true;
+				duplicated_item.push(row.item_code);
 			}
 
 			item_list.push(row.item_code);
-		});
+		}
 
+		if (duplicated) {
+			duplicated_item = [...new Set(duplicated_item)];
+			frappe.throw(__("Item(s) " + duplicated_item.join(", ") + " are duplicated. Please remove the duplicate before proceeding to create Pick List."));
+		}
+		
 		// confirm item availability
 		var items = cur_frm.doc.items
 		var flag = 0;

--- a/metactical/custom_scripts/sales_order/sales_order.js
+++ b/metactical/custom_scripts/sales_order/sales_order.js
@@ -183,46 +183,7 @@ frappe.ui.form.on('Sales Order', {
 		dialog.show();
 	},
 	
-	create_pick_list_custom: async function(frm) {
-		// validating shipping address name
-		if (!frm.doc.shipping_address_name) {
-			frappe.throw(__("Please select Shipping Address Name before proceeding to create Pick List."));
-		}
-
-		// Validating there is no duplicated items
-		var item_list = [];
-		var duplicated = false;
-		var duplicated_item = [];
-		for (const row of cur_frm.doc.items) {
-			let result = await frappe.call({
-				'method': 'metactical.custom_scripts.sales_order.sales_order.get_product_bundle_items',
-				'args': { 'item_code': row.item_code }
-			});
-
-			if (result.message && result.message.length > 0) {
-				let product_bundle_items = result.message;
-				for (const pb_item of product_bundle_items) {
-					if (item_list.includes(pb_item.item_code)) {
-						duplicated = true;
-						duplicated_item.push(pb_item.item_code);
-					}
-					item_list.push(pb_item.item_code);
-				}
-			}
-
-			if (item_list.includes(row.item_code)) {
-				duplicated = true;
-				duplicated_item.push(row.item_code);
-			}
-
-			item_list.push(row.item_code);
-		}
-
-		if (duplicated) {
-			duplicated_item = [...new Set(duplicated_item)];
-			frappe.throw(__("Item(s) " + duplicated_item.join(", ") + " are duplicated. Please remove the duplicate before proceeding to create Pick List."));
-		}
-		
+	create_pick_list_custom: function(frm) {
 		// confirm item availability
 		var items = cur_frm.doc.items
 		var flag = 0;

--- a/metactical/custom_scripts/sales_order/sales_order.js
+++ b/metactical/custom_scripts/sales_order/sales_order.js
@@ -184,6 +184,11 @@ frappe.ui.form.on('Sales Order', {
 	},
 	
 	create_pick_list_custom: function(frm) {
+		// validate shipping address before creating pick list
+		if (!frm.doc.shipping_address_name) {
+			frappe.throw(__("Please select Shipping Address Name"));
+		}
+
 		// confirm item availability
 		var items = cur_frm.doc.items
 		var flag = 0;

--- a/metactical/custom_scripts/sales_order/sales_order.js
+++ b/metactical/custom_scripts/sales_order/sales_order.js
@@ -184,10 +184,20 @@ frappe.ui.form.on('Sales Order', {
 	},
 	
 	create_pick_list_custom: function(frm) {
-		// validate shipping address before creating pick list
+		// validating shipping address name is selected
 		if (!frm.doc.shipping_address_name) {
-			frappe.throw(__("Please select Shipping Address Name"));
+			frappe.throw(__("Please select Shipping Address Name before proceeding to create Pick List."));
 		}
+
+		// Validating there is no duplicated items
+		var items = cur_frm.doc.items
+		var item_list = [];
+		items.forEach(function(row){
+			item_list.push(row.item_code);
+			if (item_list.includes(row.item_code)) {
+				frappe.throw(__("Item " + row.item_code + " is duplicated. Please remove the duplicate before proceeding to create Pick List.") );
+			}
+		});
 
 		// confirm item availability
 		var items = cur_frm.doc.items

--- a/metactical/custom_scripts/sales_order/sales_order.js
+++ b/metactical/custom_scripts/sales_order/sales_order.js
@@ -190,13 +190,33 @@ frappe.ui.form.on('Sales Order', {
 		}
 
 		// Validating there is no duplicated items
-		var items = cur_frm.doc.items
 		var item_list = [];
-		items.forEach(function(row){
-			item_list.push(row.item_code);
+		cur_frm.doc.items.forEach(function(row) {
+			frappe.call({
+				'method': 'metactical.custom_scripts.sales_order.sales_order.get_product_bundle_items',
+				'args': {
+					'item_code': row.item_code
+				},
+				'callback': function(result) {
+					if (result.message.length > 0) {
+						console.log("Product Bundle Items: ", result.message);
+						var product_bundle_items = result.message;
+						product_bundle_items.forEach(function(pb_item) {
+							if (item_list.includes(pb_item.item_code)) {
+								console.log("Duplicated Item in Product Bundle: ", pb_item.item_code);
+								console.log("Item List: ", item_list);
+								frappe.throw(__("Item " + pb_item.item_code + " is duplicated from the product bundle. Please remove the duplicate before proceeding to create Pick List."));
+							}
+							item_list.push(pb_item.item_code);
+						});
+					}
+				}
+			});
 			if (item_list.includes(row.item_code)) {
-				frappe.throw(__("Item " + row.item_code + " is duplicated. Please remove the duplicate before proceeding to create Pick List.") );
+				frappe.throw(__("Item " + row.item_code + " is duplicated. Please remove the duplicate before proceeding to create Pick List."));
 			}
+
+			item_list.push(row.item_code);
 		});
 
 		// confirm item availability

--- a/metactical/custom_scripts/sales_order/sales_order.py
+++ b/metactical/custom_scripts/sales_order/sales_order.py
@@ -285,15 +285,3 @@ def submit_order(doc):
 		queue_action(doc, "submit", timeout=2000)
 	else:
 		doc._submit()
-    
-def is_product_bundle(item_code):
-	return frappe.db.exists("Product Bundle", {"name": item_code, "disabled": 0})
-
-@frappe.whitelist()
-def get_product_bundle_items(item_code):
-	items = []
-	if is_product_bundle(item_code):
-		items = frappe.get_all("Product Bundle Item", 
-			filters={"parent": item_code},
-			fields=["item_code"])
-	return items

--- a/metactical/custom_scripts/sales_order/sales_order.py
+++ b/metactical/custom_scripts/sales_order/sales_order.py
@@ -271,3 +271,29 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 	doclist.set_onload("ignore_price_list", True)
  
 	return doclist
+
+@frappe.whitelist()
+def submit_order(doc):
+	# Metactical Customization: Submit order in background if more than 10 items
+	doc = frappe.get_doc("Sales Order", doc)
+	if len(doc.items) > 25:
+		msgprint(
+			_(
+				"The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this document and revert to the Draft stage"
+			)
+		)
+		queue_action(doc, "submit", timeout=2000)
+	else:
+		doc._submit()
+    
+def is_product_bundle(item_code):
+	return frappe.db.exists("Product Bundle", {"name": item_code, "disabled": 0})
+
+@frappe.whitelist()
+def get_product_bundle_items(item_code):
+	items = []
+	if is_product_bundle(item_code):
+		items = frappe.get_all("Product Bundle Item", 
+			filters={"parent": item_code},
+			fields=["item_code"])
+	return items

--- a/metactical/custom_scripts/sales_order/sales_order.py
+++ b/metactical/custom_scripts/sales_order/sales_order.py
@@ -271,17 +271,3 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 	doclist.set_onload("ignore_price_list", True)
  
 	return doclist
-
-@frappe.whitelist()
-def submit_order(doc):
-	# Metactical Customization: Submit order in background if more than 10 items
-	doc = frappe.get_doc("Sales Order", doc)
-	if len(doc.items) > 25:
-		msgprint(
-			_(
-				"The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this document and revert to the Draft stage"
-			)
-		)
-		queue_action(doc, "submit", timeout=2000)
-	else:
-		doc._submit()

--- a/metactical/custom_scripts/utils/orders_api.py
+++ b/metactical/custom_scripts/utils/orders_api.py
@@ -697,7 +697,7 @@ def get_taxes_and_charges(province, country, company=None):
 	elif province == "Prince Edward Island":
 		return "Prince Edward Island - ICL"
 	elif province == "Quebec":
-		return "Quebec - GST - ICL"
+		return "Quebec GST and QST - ICL"
 	elif province == "Saskatchewan":
 		return "Saskatchewan - ICL"
 	elif province == "Northwest Territories":


### PR DESCRIPTION
This pull request introduces several improvements and customizations to the Pick List and Sales Order workflows, focusing on validation, UI enhancements, and process automation. The main changes include stricter validation for Pick Lists, UI adjustments for custom buttons, and background submission for large Sales Orders.

**Pick List enhancements:**

* Added new validation logic to the `CustomPickList` class to ensure that each referenced Sales Order has a shipping address and that there are no duplicated items across Sales Orders. This helps prevent data entry errors before saving a Pick List.
* Updated the Pick List UI by removing the default "Get Items" button and introducing a custom version that is only available for draft Delivery Pick Lists, with improved filtering logic for selecting Sales Orders. [[1]](diffhunk://#diff-bf1fd89f28027e920ba385d1fa4f9b0df445291b24ad9c90e0325e002c6a5e10R3-R5) [[2]](diffhunk://#diff-bf1fd89f28027e920ba385d1fa4f9b0df445291b24ad9c90e0325e002c6a5e10R55-R77)

**Sales Order workflow improvements:**

* Added a new method to submit Sales Orders in the background if they contain more than 25 items, improving performance and user experience for large orders. Users are notified when the task is enqueued.
* Minor adjustment to custom buttons: the removal of the "Work Order" button is now commented out, potentially allowing it to remain available.

**Tax configuration fix:**

* Corrected the tax template returned for Quebec to "Quebec GST and QST - ICL" for improved accuracy in tax calculations.