### PR TITLE
Bulk Update for child tables in the Item Form

### DIFF
--- a/metactical/custom_scripts/item/item.py
+++ b/metactical/custom_scripts/item/item.py
@@ -207,3 +207,82 @@ def get_sb_tag(label, description):
         return sb_tag[0].sb_tag
     else:
         return None
+    
+@frappe.whitelist()
+def update_child_table(item_names, child_table, child_table_field, updates, updating=False):
+    item_names = json.loads(item_names)
+    updates = json.loads(updates)
+    
+    total_updated_items = 0
+    
+    if updating:
+        # clear the child table for each selected item and then add the updates
+        for item_name in item_names:
+            item = frappe.get_doc("Item", item_name)
+            item.set(child_table_field, [])
+            
+            for update in updates:
+                new_row = item.append(child_table_field, {})
+                for key, value in update.items():
+                    if key in ["name", "idx"]:
+                        continue
+                    
+                    setattr(new_row, key, value)
+                    
+            item.save()
+            item.reload()
+            total_updated_items += 1
+
+    else:
+        if child_table == "MT Item Website Specification":
+            for item_name in item_names:
+                # if the label exists, update the description, else add a new row
+                item = frappe.get_doc("Item", item_name)
+                for update in updates:
+                    found = False
+                    for spec in item.neb_website_specifications:
+                        if spec.label == update['label']:
+                            spec.description = update['description'] if "description" in update else ""
+                            spec.mandatory = update['mandatory'] if "mandatory" in update else 0
+                            found = True
+                            break
+                    
+                    if not found:       
+                        new_spec = item.append("neb_website_specifications", {})
+                        new_spec.label = update['label']
+                        new_spec.mandatory = update['mandatory'] if "mandatory" in update else 0
+                        new_spec.description = update['description'] if "description" in update else ""
+
+                item.save()
+                item.reload()
+                total_updated_items += 1
+                
+        elif child_table == "Months List":
+            for item_name in item_names:
+                # if the month exists, continue, else add a new row
+                item = frappe.get_doc("Item", item_name)
+                exitsing_months = [month.month for month in item.months_to_reorder]
+                for update in updates:
+                    if update['month'] not in exitsing_months:
+                        new_month = item.append("months_to_reorder", {})
+                        new_month.month = update['month']
+                        
+                item.save()
+                item.reload()
+                total_updated_items += 1
+        else:
+            # add a new row with the updates to the child table for each selected item
+            for item_name in item_names:
+                
+                item = frappe.get_doc("Item", item_name)
+                new_row = item.append(child_table_field, {})
+                for key, value in updates[0].items():
+                    if key in ["name", "idx"]:
+                        continue
+                    
+                    setattr(new_row, key, value)
+                item.save()
+                item.reload()
+                total_updated_items += 1
+                
+    return total_updated_items

--- a/metactical/custom_scripts/item/item_list.js
+++ b/metactical/custom_scripts/item/item_list.js
@@ -1,120 +1,147 @@
 function edit_child_table(listview) {
+    let selected_items = listview.get_checked_items();
+    if (selected_items.length === 0) {
+        frappe.msgprint(__("Please select at least one item to update."));
+        return;
+    }
+
     var all_fields = frappe.meta.get_docfields("Item", listview.doctype, true);
 
     let child_table_map = {};
     let child_table_options = [];
+    let all_child_tables = [];
 
     all_fields.forEach((field) => {
-        if (field.fieldtype === "Table" && field.options) {
+        if ((field.fieldtype === "Table" || field.fieldtype === "Table MultiSelect") && field.options) {
             child_table_map[field.fieldname] = field.options;
-            child_table_options.push({
-                label: `${field.label}`,
-                value: field.fieldname,
-            });
+            child_table_options.push(field.options);
+            all_child_tables.push(field);
         }
     });
+
 
     if (Object.keys(child_table_map).length === 0) {
         frappe.msgprint(__("No child tables found in this doctype."));
         return;
     }
 
+    let selected_items_name = selected_items.map(i => i.name)
+
+    frappe.prompt([
+        {
+            label: __("Select Child Table"),
+            fieldname: "child_table",
+            fieldtype: "Select",
+            options: child_table_options,
+            reqd: 1,
+        },
+        {
+            label: __("Update All Selected Items Based On"),
+            fieldname: "update_based_on",
+            fieldtype: "Select",
+            options: selected_items_name.join("\n"),
+        }
+    ], function(values) {
+        let child_fieldname = values.child_table;
+        if (!child_fieldname) return;
+
+        open_main_dialog(selected_items, values, all_child_tables);
+    }, __("Select Child Table"), __("Load"));
+}
+
+function open_main_dialog(selected_items, values, all_child_tables) {
+    let child_table = values.child_table;
+    let selected_based_on = values.update_based_on;
+    let fields = frappe.meta.get_docfields(child_table);
+    let child_table_field = all_child_tables.find(f => f.options === child_table);
+
+    console.log("Opening dialog for", child_table, "based on", selected_based_on);
+    let item = null;
+    frappe.call({
+        method: "frappe.client.get",
+        args: {
+            doctype: "Item",
+            name: selected_based_on,
+        },
+        freeze: true,
+        freeze_message: __("Loading item..."),
+        async: false,
+        callback: function(r) {
+            if (r.message) {
+                item = r.message;
+            } else {
+                frappe.msgprint(__("Could not load the selected item."));
+                return;
+            }
+        }
+    });
+
+    if (child_table === "MT Item Website Specification") {
+        fields = fields.map(f => {
+            if (f.fieldname === "label") {
+                f.onchange = function() {
+                    console.log("Label changed to", this.value);
+                    var grid_row = this.grid_row;
+                    
+                    frappe.call({
+                        method: "metactical.custom_scripts.item.item.get_website_specification_description_options",
+                        args: {
+                            labels: [this.value],
+                        },
+                        callback: function (r) {
+                            var descriptions = r.message.map(row => row.description)                            
+                            let desc_field = grid_row.on_grid_fields_dict.description;
+
+                            desc_field.df.options = descriptions;
+                            desc_field.refresh();
+                        },
+                    })
+                };
+            }
+            return f;
+        });
+    }
+
+
     let dialog = new frappe.ui.Dialog({
-        title: __('Bulk Edit Child Table'),
+        title: __('Edit - {0}', [child_table_field.label]),
+        size: 'extra-large ',
         fields: [
             {
-                label: __("Child Table"),
+                label: __(child_table_field.label),
                 fieldname: "child_table",
-                fieldtype: "Select",
-                options: child_table_options,
-                reqd: 1,
-            },
-            { fieldtype: "Section Break" },
-            {
-                label: __("Child Table Data"),
-                fieldname: "child_table_data",
-                fieldtype: "HTML",
-            },
+                fieldtype: "Table",
+                options: child_table,
+                in_place_edit: true,
+                fields: fields,
+                get_data: function() {
+                    return item[child_table_field.fieldname] || [];
+                }
+            }
         ],
         primary_action_label: __("Save"),
         primary_action(values) {
-            let child_fieldname = values.child_table;
-            if (!dialog.fields_dict._table_control) {
-                frappe.msgprint(__("Please select a child table and load data first."));
-                return;
-            }
-            let updates = dialog.fields_dict._table_control.get_value();
-
-            let selected_items = listview.get_checked_items();
-            if (selected_items.length === 0) {
-                frappe.msgprint(__("Please select at least one item to update."));
-                return;
-            }
-
-            let promises = selected_items.map((item) => {
-                return frappe.call({
-                    method: "frappe.client.set_value",
-                    args: {
-                        doctype: "Item",
-                        name: item.name,
-                        fieldname: child_fieldname,
-                        value: updates,
-                    },
-                });
-            });
-
-            Promise.all(promises).then(() => {
-                frappe.msgprint(__("Child table updated successfully for selected items."));
-                dialog.hide();
-                listview.refresh();
-            });
+            let updates = dialog.fields_dict.child_table.get_value();
+            console.log(selected_items, updates);
+            frappe.call({
+                method: "metactical.custom_scripts.item.item.update_child_table",
+                args: {
+                    item_names: selected_items.map(i => i.name),
+                    child_table: child_table,
+                    child_table_field: child_table_field.fieldname,
+                    updates: updates,
+                    updating: selected_based_on ? true : false,
+                },
+                freeze: true,
+                freeze_message: __("Updating items..."),
+                callback: function(r) {
+                    frappe.msgprint(__("{0} items updated", [r.message]));
+                    dialog.hide();
+                    listview.refresh();
+                }
+            })
         },
     });
-
-    dialog.fields_dict["child_table"].df.onchange = () => {
-        let child_fieldname = dialog.get_value("child_table");
-        if (!child_fieldname) return;
-
-        let child_doctype = child_table_map[child_fieldname];
-        if (!child_doctype) {
-            frappe.msgprint(__("Could not resolve child doctype for " + child_fieldname));
-            return;
-        }
-
-        let first_item = listview.get_checked_items()[0];
-        if (!first_item) {
-            frappe.msgprint(__("Please select at least one item."));
-            return;
-        }
-
-        frappe.call({
-            method: "frappe.client.get",
-            args: { doctype: "Item", name: first_item.name, with_childnames: 1 },
-        }).then(({ message }) => {
-            let data = [];
-            if (message && message[child_fieldname]) {
-                data = message[child_fieldname];
-            }
-
-            dialog.fields_dict.child_table_data.$wrapper.empty();
-            let table_control = frappe.ui.form.make_control({
-                parent: dialog.fields_dict.child_table_data.$wrapper,
-                df: {
-                    fieldtype: "Table",
-                    fieldname: "child_table_data",
-                    label: __(child_doctype),
-                    options: child_doctype,
-                    in_place_edit: true,
-                    get_data: () => data, 
-                },
-                render_input: true,
-            });
-
-            table_control.make();
-            table_control.refresh();
-            dialog.fields_dict._table_control = table_control;
-        });
-    };
 
     dialog.show();
 }
@@ -122,7 +149,7 @@ function edit_child_table(listview) {
 
 frappe.listview_settings['Item'] = {
     refresh: function(listview) {
-        listview.page.add_inner_button("Edit Child Table", function() {
+        listview.page.add_action_item("Child Table Bulk Update", function() {
             edit_child_table(listview); 
         }); 
     }, 

--- a/metactical/custom_scripts/item/item_list.js
+++ b/metactical/custom_scripts/item/item_list.js
@@ -55,38 +55,60 @@ function open_main_dialog(selected_items, values, all_child_tables) {
     let fields = frappe.meta.get_docfields(child_table);
     let child_table_field = all_child_tables.find(f => f.options === child_table);
 
-    console.log("Opening dialog for", child_table, "based on", selected_based_on);
-    let item = null;
-    frappe.call({
-        method: "frappe.client.get",
-        args: {
-            doctype: "Item",
-            name: selected_based_on,
-        },
-        freeze: true,
-        freeze_message: __("Loading item..."),
-        async: false,
-        callback: function(r) {
-            if (r.message) {
-                item = r.message;
-            } else {
-                frappe.msgprint(__("Could not load the selected item."));
-                return;
+    let item = {};
+    if (selected_based_on){
+        frappe.call({
+            method: "frappe.client.get",
+            args: {
+                doctype: "Item",
+                name: selected_based_on,
+            },
+            freeze: true,
+            freeze_message: __("Loading item..."),
+            async: false,
+            callback: function(r) {
+                if (r.message) {
+                    item = r.message;
+                } else {
+                    frappe.msgprint(__("Could not load the selected item."));
+                    return;
+                }
             }
-        }
-    });
+        });
+    }
 
     if (child_table === "MT Item Website Specification") {
         fields = fields.map(f => {
             if (f.fieldname === "label") {
-                f.onchange = function() {
-                    console.log("Label changed to", this.value);
+                f.change = function() {
+                    console.log("Label changed to", this.get_value());
                     var grid_row = this.grid_row;
                     
                     frappe.call({
                         method: "metactical.custom_scripts.item.item.get_website_specification_description_options",
                         args: {
-                            labels: [this.value],
+                            labels: [this.get_value()],
+                        },
+                        callback: function (r) {
+                            var descriptions = r.message.map(row => row.description)                            
+                            let desc_field = grid_row.on_grid_fields_dict.description;
+
+                            desc_field.df.options = descriptions;
+                            desc_field.refresh();
+                        },
+                    })
+                };
+            }
+            else if (f.fieldname === "mandatory") {
+                f.read_only_depends_on = 0;
+                f.change = function() {
+                    var grid_row = this.grid_row;
+                    var label = grid_row.doc.label;
+                    
+                    frappe.call({
+                        method: "metactical.custom_scripts.item.item.get_website_specification_description_options",
+                        args: {
+                            labels: [label],
                         },
                         callback: function (r) {
                             var descriptions = r.message.map(row => row.description)                            
@@ -122,7 +144,6 @@ function open_main_dialog(selected_items, values, all_child_tables) {
         primary_action_label: __("Save"),
         primary_action(values) {
             let updates = dialog.fields_dict.child_table.get_value();
-            console.log(selected_items, updates);
             frappe.call({
                 method: "metactical.custom_scripts.item.item.update_child_table",
                 args: {

--- a/metactical/custom_scripts/item/item_list.js
+++ b/metactical/custom_scripts/item/item_list.js
@@ -1,115 +1,129 @@
 function edit_child_table(listview) {
     var all_fields = frappe.meta.get_docfields("Item", listview.doctype, true);
-    var child_fields = all_fields.filter((field) => field.fieldtype === "Table");
-    if (child_fields.length === 0) {
+
+    let child_table_map = {};
+    let child_table_options = [];
+
+    all_fields.forEach((field) => {
+        if (field.fieldtype === "Table" && field.options) {
+            child_table_map[field.fieldname] = field.options;
+            child_table_options.push({
+                label: `${field.label}`,
+                value: field.fieldname,
+            });
+        }
+    });
+
+    if (Object.keys(child_table_map).length === 0) {
         frappe.msgprint(__("No child tables found in this doctype."));
         return;
     }
 
-    // create a dialog to select the child table
-    var d = new frappe.ui.Dialog({
-        title: __("Select Child Table to Edit"),
+    let dialog = new frappe.ui.Dialog({
+        title: __('Bulk Edit Child Table'),
         fields: [
             {
                 label: __("Child Table"),
                 fieldname: "child_table",
                 fieldtype: "Select",
-                options: child_fields.map((field) => field.options),
+                options: child_table_options,
                 reqd: 1,
             },
-        ],
-        primary_action_label: __("Edit"),
-        primary_action(values) {
-            d.hide();
-            var child_table = values.child_table;
-            if (!child_table) {
-                frappe.msgprint(__("Please select a child table."));
-                return;
-            }
-
-
-
-            // Fetch existing data for the child table from the first selected item
-            var first_item = listview.get_checked_items()[0];
-            frappe.call({
-                method: "frappe.client.get",
-                args: {
-                    doctype: "Item",
-                    name: first_item.name,
-                },
-                callback: function (r) {
-                    // if (r.message && r.message[child_table]) {
-                    //     child_table_dialog.set_value("child_table_data", r.message[child_table]);
-                    // }
-                },
-            });
-
-            child_table_dialog.show();
-        },
-    });
-
-    d.show();
-}
-
-
-function update_child_table_dialog(listview, child_table) {
-    // Open the child table in a new dialog
-    var child_table_dialog = new frappe.ui.Dialog({
-        title: __("Edit {0}", [child_table]),
-        fields: [
+            { fieldtype: "Section Break" },
             {
-                label: __(child_table),
+                label: __("Child Table Data"),
                 fieldname: "child_table_data",
-                fieldtype: "Table",
-                options: child_table,
-                reqd: 1,
-                in_place_edit: true,
-                data: [],
+                fieldtype: "HTML",
             },
         ],
         primary_action_label: __("Save"),
-        primary_action(child_values) {
-            // Save the changes to all selected items
-            var selected_items = listview.get_checked_items();
+        primary_action(values) {
+            let child_fieldname = values.child_table;
+            if (!dialog.fields_dict._table_control) {
+                frappe.msgprint(__("Please select a child table and load data first."));
+                return;
+            }
+            let updates = dialog.fields_dict._table_control.get_value();
+
+            let selected_items = listview.get_checked_items();
             if (selected_items.length === 0) {
                 frappe.msgprint(__("Please select at least one item to update."));
                 return;
             }
 
-            var updates = child_values.child_table_data;
-
-            // Prepare the updates for each selected item
-            var promises = selected_items.map((item) => {
+            let promises = selected_items.map((item) => {
                 return frappe.call({
                     method: "frappe.client.set_value",
                     args: {
                         doctype: "Item",
                         name: item.name,
-                        fieldname: child_table,
+                        fieldname: child_fieldname,
                         value: updates,
                     },
                 });
             });
 
-            // Wait for all updates to complete
-            Promise.all(promises)
-                .then(() => {
-                    frappe.msgprint(__("Child table updated successfully for selected items."));
-                    child_table_dialog.hide();
-                    listview.refresh();
-                })
-                .catch((error) => {
-                    frappe.msgprint(__("Error updating child table: {0}", [error.message]));
-                });
+            Promise.all(promises).then(() => {
+                frappe.msgprint(__("Child table updated successfully for selected items."));
+                dialog.hide();
+                listview.refresh();
+            });
         },
     });
 
+    dialog.fields_dict["child_table"].df.onchange = () => {
+        let child_fieldname = dialog.get_value("child_table");
+        if (!child_fieldname) return;
+
+        let child_doctype = child_table_map[child_fieldname];
+        if (!child_doctype) {
+            frappe.msgprint(__("Could not resolve child doctype for " + child_fieldname));
+            return;
+        }
+
+        let first_item = listview.get_checked_items()[0];
+        if (!first_item) {
+            frappe.msgprint(__("Please select at least one item."));
+            return;
+        }
+
+        frappe.call({
+            method: "frappe.client.get",
+            args: { doctype: "Item", name: first_item.name, with_childnames: 1 },
+        }).then(({ message }) => {
+            let data = [];
+            if (message && message[child_fieldname]) {
+                data = message[child_fieldname];
+            }
+
+            dialog.fields_dict.child_table_data.$wrapper.empty();
+            let table_control = frappe.ui.form.make_control({
+                parent: dialog.fields_dict.child_table_data.$wrapper,
+                df: {
+                    fieldtype: "Table",
+                    fieldname: "child_table_data",
+                    label: __(child_doctype),
+                    options: child_doctype,
+                    in_place_edit: true,
+                    get_data: () => data, 
+                },
+                render_input: true,
+            });
+
+            table_control.make();
+            table_control.refresh();
+            dialog.fields_dict._table_control = table_control;
+        });
+    };
+
+    dialog.show();
 }
 
+
 frappe.listview_settings['Item'] = {
-   refresh: function(listview) {
-       listview.page.add_inner_button("Edit Child Table", function() {
-           edit_child_table(listview);
-       });
-   },
+    refresh: function(listview) {
+        listview.page.add_inner_button("Edit Child Table", function() {
+            edit_child_table(listview); 
+        }); 
+    }, 
 };

--- a/metactical/custom_scripts/item/item_list.js
+++ b/metactical/custom_scripts/item/item_list.js
@@ -1,0 +1,115 @@
+function edit_child_table(listview) {
+    var all_fields = frappe.meta.get_docfields("Item", listview.doctype, true);
+    var child_fields = all_fields.filter((field) => field.fieldtype === "Table");
+    if (child_fields.length === 0) {
+        frappe.msgprint(__("No child tables found in this doctype."));
+        return;
+    }
+
+    // create a dialog to select the child table
+    var d = new frappe.ui.Dialog({
+        title: __("Select Child Table to Edit"),
+        fields: [
+            {
+                label: __("Child Table"),
+                fieldname: "child_table",
+                fieldtype: "Select",
+                options: child_fields.map((field) => field.options),
+                reqd: 1,
+            },
+        ],
+        primary_action_label: __("Edit"),
+        primary_action(values) {
+            d.hide();
+            var child_table = values.child_table;
+            if (!child_table) {
+                frappe.msgprint(__("Please select a child table."));
+                return;
+            }
+
+
+
+            // Fetch existing data for the child table from the first selected item
+            var first_item = listview.get_checked_items()[0];
+            frappe.call({
+                method: "frappe.client.get",
+                args: {
+                    doctype: "Item",
+                    name: first_item.name,
+                },
+                callback: function (r) {
+                    // if (r.message && r.message[child_table]) {
+                    //     child_table_dialog.set_value("child_table_data", r.message[child_table]);
+                    // }
+                },
+            });
+
+            child_table_dialog.show();
+        },
+    });
+
+    d.show();
+}
+
+
+function update_child_table_dialog(listview, child_table) {
+    // Open the child table in a new dialog
+    var child_table_dialog = new frappe.ui.Dialog({
+        title: __("Edit {0}", [child_table]),
+        fields: [
+            {
+                label: __(child_table),
+                fieldname: "child_table_data",
+                fieldtype: "Table",
+                options: child_table,
+                reqd: 1,
+                in_place_edit: true,
+                data: [],
+            },
+        ],
+        primary_action_label: __("Save"),
+        primary_action(child_values) {
+            // Save the changes to all selected items
+            var selected_items = listview.get_checked_items();
+            if (selected_items.length === 0) {
+                frappe.msgprint(__("Please select at least one item to update."));
+                return;
+            }
+
+            var updates = child_values.child_table_data;
+
+            // Prepare the updates for each selected item
+            var promises = selected_items.map((item) => {
+                return frappe.call({
+                    method: "frappe.client.set_value",
+                    args: {
+                        doctype: "Item",
+                        name: item.name,
+                        fieldname: child_table,
+                        value: updates,
+                    },
+                });
+            });
+
+            // Wait for all updates to complete
+            Promise.all(promises)
+                .then(() => {
+                    frappe.msgprint(__("Child table updated successfully for selected items."));
+                    child_table_dialog.hide();
+                    listview.refresh();
+                })
+                .catch((error) => {
+                    frappe.msgprint(__("Error updating child table: {0}", [error.message]));
+                });
+        },
+    });
+
+}
+
+frappe.listview_settings['Item'] = {
+   refresh: function(listview) {
+       listview.page.add_inner_button("Edit Child Table", function() {
+           edit_child_table(listview);
+       });
+   },
+};

--- a/metactical/hooks.py
+++ b/metactical/hooks.py
@@ -63,7 +63,8 @@ doctype_list_js = {
 	"Stock Reconciliation": "custom_scripts/stock_reconciliation/stock_reconciliation_list.js",
 	"Task": "custom_scripts/task/task_list.js",
 	"Project": "custom_scripts/project/project_list.js",
-	"Pick List": "custom_scripts/pick_list/pick_list_list.js"
+	"Pick List": "custom_scripts/pick_list/pick_list_list.js",
+	"Item": "custom_scripts/item/item_list.js",
 }
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}


### PR DESCRIPTION
This pull request adds a new feature for bulk updating child tables in the `Item` doctype, making it easier to manage and update related records across multiple items from the list view. The main changes include introducing a client-side dialog for selecting and editing child tables, implementing a server-side method for applying updates, and registering the new functionality in the system hooks.

**Bulk Child Table Update Feature:**

* Added a new client-side function `edit_child_table` in `item_list.js` that allows users to select multiple items and bulk update their child tables via a dialog, with support for different child table types and dynamic field handling.
* Implemented the `update_child_table` server-side method in `item.py` to handle bulk updates to child tables, supporting both full replacement and incremental updates based on the selected mode and child table type.

**Integration and Registration:**

* Registered the new `item_list.js` script for the `Item` doctype in `hooks.py` to enable the bulk update feature in the list view.