### PR TITLE
Fix to re-open closed sales orders

### DIFF
--- a/metactical/custom_scripts/sales_order/sales_order.js
+++ b/metactical/custom_scripts/sales_order/sales_order.js
@@ -528,6 +528,22 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			'Close'
 		)
 	}
+
+	update_status(label, status) {
+		var doc = this.frm.doc;
+		var me = this;
+		frappe.ui.form.is_saving = true;
+		frappe.call({
+			method: "metactical.custom_scripts.sales_order.sales_order.update_status",
+			args: {status: status, name: doc.name, label: label},
+			callback: function(r){
+				me.frm.reload_doc();
+			},
+			always: function() {
+				frappe.ui.form.is_saving = false;
+			}
+		});
+	}
 };
 
 extend_cscript(cur_frm.cscript, new erpnext.selling.SalesOrderController({frm: cur_frm}));

--- a/metactical/custom_scripts/sales_order/sales_order.js
+++ b/metactical/custom_scripts/sales_order/sales_order.js
@@ -528,22 +528,6 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			'Close'
 		)
 	}
-
-	update_status(label, status) {
-		var doc = this.frm.doc;
-		var me = this;
-		frappe.ui.form.is_saving = true;
-		frappe.call({
-			method: "metactical.custom_scripts.sales_order.sales_order.update_status",
-			args: {status: status, name: doc.name, label: label},
-			callback: function(r){
-				me.frm.reload_doc();
-			},
-			always: function() {
-				frappe.ui.form.is_saving = false;
-			}
-		});
-	}
 };
 
 extend_cscript(cur_frm.cscript, new erpnext.selling.SalesOrderController({frm: cur_frm}));

--- a/metactical/custom_scripts/sales_order/sales_order.py
+++ b/metactical/custom_scripts/sales_order/sales_order.py
@@ -49,19 +49,9 @@ class SalesOrderCustom(SalesOrder):
 					'warehouse': row.warehouse}, 'reserved_qty')
 				row.update({'sal_reserved_qty': reserved_qty})
 
-	def update_status(self, status, label):
-			self.check_modified_date()
-			self.set_status(update=True, status=status, label=label)
-			# Upon Sales Order Re-open, check for credit limit.
-			# Limit should be checked after the 'Hold/Closed' status is reset.
-			if status == "Draft" and self.docstatus == 1:
-				self.check_credit_limit()
-			self.update_reserved_qty()
-			self.notify_update()
-			clear_doctype_notifications(self)
-
-	def set_status(self, update=False, status=None, update_modified=True, label=""):
+	def set_status(self, update=False, status=None, update_modified=True):
 		super(SalesOrderCustom, self).set_status(update, status, update_modified)
+		from_ui = frappe.flags.get('from_ui', False)
 
 		# Metactical Customization: Added
 		if self.billing_status == "Fully Billed" and not self.neb_payment_completed_at:
@@ -69,7 +59,7 @@ class SalesOrderCustom(SalesOrder):
 			if all_invoices_paid:
 				self.db_set("neb_payment_completed_at", frappe.utils.getdate(frappe.utils.now()), notify=True)
 
-		if self.status in ["To Deliver", "To Bill", "To Deliver and Bill"] and label != "Re-open":
+		if self.status in ["To Deliver", "To Bill", "To Deliver and Bill"] and not from_ui:
 			# check if there is return delivery note created in 
 			has_linked_return = False
 			return_delivery_notes = get_return_delivery_note(self.name)
@@ -283,8 +273,9 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 	doclist.set_onload("ignore_price_list", True)
  
 	return doclist
-
+  
 @frappe.whitelist()
-def update_status(status, name, label):
+def update_status(status, name):
 	so = frappe.get_doc("Sales Order", name)
-	so.update_status(status, label=label)
+	frappe.flags.from_ui = True
+	so.update_status(status)

--- a/metactical/custom_scripts/sales_order/sales_order.py
+++ b/metactical/custom_scripts/sales_order/sales_order.py
@@ -11,6 +11,7 @@ from erpnext.stock.doctype.item.item import get_item_defaults
 from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 from frappe.model.utils import get_fetch_values
 from erpnext.selling.doctype.sales_order.sales_order import SalesOrder
+from frappe.desk.notifications import clear_doctype_notifications
 from erpnext.accounts.party import get_party_account
 from frappe import _, msgprint
 from metactical.metactical.doctype.item_inventory_output.item_inventory_output import update_item_inventory_output
@@ -48,7 +49,18 @@ class SalesOrderCustom(SalesOrder):
 					'warehouse': row.warehouse}, 'reserved_qty')
 				row.update({'sal_reserved_qty': reserved_qty})
 
-	def set_status(self, update=False, status=None, update_modified=True):
+	def update_status(self, status, label):
+			self.check_modified_date()
+			self.set_status(update=True, status=status, label=label)
+			# Upon Sales Order Re-open, check for credit limit.
+			# Limit should be checked after the 'Hold/Closed' status is reset.
+			if status == "Draft" and self.docstatus == 1:
+				self.check_credit_limit()
+			self.update_reserved_qty()
+			self.notify_update()
+			clear_doctype_notifications(self)
+
+	def set_status(self, update=False, status=None, update_modified=True, label=""):
 		super(SalesOrderCustom, self).set_status(update, status, update_modified)
 
 		# Metactical Customization: Added
@@ -57,7 +69,7 @@ class SalesOrderCustom(SalesOrder):
 			if all_invoices_paid:
 				self.db_set("neb_payment_completed_at", frappe.utils.getdate(frappe.utils.now()), notify=True)
 
-		if self.status in ["To Deliver", "To Bill", "To Deliver and Bill"]:
+		if self.status in ["To Deliver", "To Bill", "To Deliver and Bill"] and label != "Re-open":
 			# check if there is return delivery note created in 
 			has_linked_return = False
 			return_delivery_notes = get_return_delivery_note(self.name)
@@ -271,3 +283,8 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 	doclist.set_onload("ignore_price_list", True)
  
 	return doclist
+
+@frappe.whitelist()
+def update_status(status, name, label):
+	so = frappe.get_doc("Sales Order", name)
+	so.update_status(status, label=label)

--- a/metactical/custom_scripts/sales_order/sales_order.py
+++ b/metactical/custom_scripts/sales_order/sales_order.py
@@ -11,7 +11,6 @@ from erpnext.stock.doctype.item.item import get_item_defaults
 from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 from frappe.model.utils import get_fetch_values
 from erpnext.selling.doctype.sales_order.sales_order import SalesOrder
-from frappe.desk.notifications import clear_doctype_notifications
 from erpnext.accounts.party import get_party_account
 from frappe import _, msgprint
 from metactical.metactical.doctype.item_inventory_output.item_inventory_output import update_item_inventory_output

--- a/metactical/hooks.py
+++ b/metactical/hooks.py
@@ -233,6 +233,7 @@ override_whitelisted_methods = {
 	"erpnext.stock.doctype.pick_list.pick_list.create_delivery_note": "metactical.custom_scripts.pick_list.pick_list.create_delivery_note",
 	"erpnext.stock.get_item_details.get_item_details": "metactical.custom_scripts.get_item_details.get_item_details",
 	"erpnext.selling.doctype.sales_order.sales_order.make_sales_invoice": "metactical.custom_scripts.sales_order.sales_order.make_sales_invoice",
+	"erpnext.selling.doctype.sales_order.sales_order.update_status": "metactical.custom_scripts.sales_order.sales_order.update_status",
 	"erpnext.stock.doctype.pick_list.pick_list.PickList.set_item_locations": "metactical.custom_scripts.pick_list.pick_list.CustomPickList.set_item_locations",
 	"frappe.desk.doctype.tag.tag.add_tag": "metactical.custom_scripts.tag.tag.add_tag",
 	"frappe.desk.doctype.tag.tag.remove_tag": "metactical.custom_scripts.tag.tag.remove_tag",


### PR DESCRIPTION
This pull request introduces a mechanism to safely update the status of a Sales Order from the UI, preventing unintended side effects that could occur when status updates are triggered programmatically. The main changes include adding a whitelisted method for status updates, modifying the status update logic to check for UI-originated requests, and registering the new method in the system hooks.

**Sales Order status update improvements:**

* Added a new whitelisted function `update_status` in `sales_order.py` to allow status updates from the UI, setting a `from_ui` flag to distinguish UI-triggered updates.
* Updated the `set_status` method in `SalesOrderCustom` to check the `from_ui` flag and prevent certain logic from running when the status is updated from the UI.

**System integration:**

* Registered the new `update_status` method in `metactical/hooks.py` to override the default ERPNext behavior for Sales Order status updates.