### PR TITLE
POS updates, sync last name for rmq orders, add missing barcodes for PR

### DIFF
--- a/metactical/custom_scripts/purchase_receipt/purchase_receipt.py
+++ b/metactical/custom_scripts/purchase_receipt/purchase_receipt.py
@@ -11,6 +11,16 @@ class CustomPurchaseReceipt(PurchaseReceipt):
 		if self.purchase_order:
 			for d in self.items:
 				d.purchase_order = self.purchase_order
+
+		self.validate_barcodes()
+    
+	def validate_barcodes(self):
+		for item in self.items:
+			if not item.barcode:
+				barcode = frappe.db.get_value("Item Barcode", {"parent": item.item_code}, "barcode")
+				if barcode:	
+					item.barcode = barcode
+     
 	def save(self):
 		if self.docstatus == DocStatus.submitted() and len(self.items) > 100 and \
 			self.ais_queue_status and self.ais_queue_status != "Queued":

--- a/metactical/custom_scripts/utils/orders_api.py
+++ b/metactical/custom_scripts/utils/orders_api.py
@@ -453,6 +453,7 @@ def create_address(address_detail, customer, address_type):
 		"doctype": "Address",
 		"title": address_detail["first_name"] + " " + address_detail["last_name"],
 		"ifw_first_name": address_detail["first_name"],
+		"ifw_last_name": address_detail["last_name"] if "last_name" in address_detail else "",
 		"email_id": address_detail["email"],
 		"phone": address_detail["phone"],
 		"company": address_detail["company"],

--- a/metactical/custom_scripts/utils/pos_api.py
+++ b/metactical/custom_scripts/utils/pos_api.py
@@ -1088,7 +1088,7 @@ def get_item_by_retail_sku(retail_sku, branch, user, page_size=10, page=1):
     items = frappe.db.sql(f"""
         SELECT
             tabItem.name AS item_code, item_name, ifw_retailskusuffix,
-            variant_of,
+            variant_of, asi_item_class, ifw_location,
             brand, image, is_stock_item, tabItem.has_variants,
             (
                 SELECT GROUP_CONCAT(barcode SEPARATOR ', ')
@@ -1208,6 +1208,8 @@ def get_item_by_retail_sku(retail_sku, branch, user, page_size=10, page=1):
             "RetailSku": item.ifw_retailskusuffix,
             "Categories": [],
             "Comment": "",
+            "ItemClass": item.asi_item_class or "",
+            "Location": item.ifw_location or "",
             "OnOrderQty": on_order,
             "TemplateId": item.variant_of or "",
             "ImageUrl": item.image or "",

--- a/metactical/custom_scripts/utils/pos_api.py
+++ b/metactical/custom_scripts/utils/pos_api.py
@@ -1231,16 +1231,32 @@ def get_item_by_retail_sku(retail_sku, branch, user, page_size=10, page=1):
     })
 
 def get_on_order_quantity(item_code, warehouse):
-    po_items = frappe.db.get_all("Purchase Order Item", filters={
-        "item_code": item_code,
-        "warehouse": warehouse,
-        "parenttype": "Purchase Order",
-    }, fields=["sum(qty) as total_qty", "sum(received_qty) as total_received"])
-
-    if po_items and po_items[0].total_qty and po_items[0].total_received is not None:
-        return int(po_items[0].total_qty - po_items[0].total_received)
+    po_items = frappe.db.sql(f"""
+        SELECT sum(qty), sum(received_qty)
+        FROM `tabPurchase Order Item` poi
+        JOIN `tabPurchase Order` po ON poi.parent = po.name
+        WHERE
+            poi.item_code = {frappe.db.escape(item_code)}
+            AND poi.warehouse = {frappe.db.escape(warehouse)}
+            AND po.docstatus = 1
+            AND po.status in ('To Receive and Bill', 'To Receive')
+            AND poi.qty > poi.received_qty
+            AND po.company = 'International Camouflage Ltd'
+        GROUP BY poi.item_code, poi.parent
+    """, as_dict=True)
     
-    return 0
+    pending_quantities = ""
+    for po in po_items:
+        pending_qty = int(po["sum(qty)"] - po["sum(received_qty)"])
+        if pending_qty > 0:
+            if pending_quantities:
+                pending_quantities += ", "
+            pending_quantities += str(pending_qty)
+
+    if pending_quantities:
+        return pending_quantities
+    
+    return ""
 
 @frappe.whitelist()
 def get_item_by_retail_sku_single(retail_sku, branch):

--- a/metactical/custom_scripts/utils/pos_api.py
+++ b/metactical/custom_scripts/utils/pos_api.py
@@ -124,11 +124,13 @@ def receive_pos_data(*args, **kwargs):
                 form_data=form_data,
                 sales_order=sales_order.name
             )
-                
+
+        auto_logout = frappe.db.get_value("POS Profile", form_data["POSProfile"] + ' Operators', "auto_logout_after_transaction")
         frappe.response["Status"] = "200"
         frappe.response["InvoiceId"] = sales_order.name
         frappe.response["Message"] = []
         frappe.response["Total"] = float(sales_order.grand_total)
+        frappe.response["AutoLogout"] = True if auto_logout else False
             
     except Exception as e:
         frappe.log_error(title='Receive POS Data Error', message=frappe.get_traceback())
@@ -904,12 +906,14 @@ def create_return(*args, **kwargs):
             frappe.response["Message"] = str(e)
     
     total = round(sales_return.grand_total + total_restock_fee, 2)
+    auto_logout = frappe.db.get_value("POS Profile", form_data["POSProfile"] + ' Operators', "auto_logout_after_transaction")
     frappe.response["Status"] = 200
     frappe.response["Message"] = ""
     frappe.response["CouponCode"] = gift_card.coupon_code if gift_card else None
     frappe.response["SalesReturn"] = sales_return.name
     frappe.response["Total"] = total
     frappe.response["TotalAfterRestockFee"] = total
+    frappe.response["AutoLogout"] = True if auto_logout else False
     frappe.db.commit()
     
 def create_restock_invoice(total_restock_fee, sales_return, form_data):
@@ -1181,6 +1185,7 @@ def get_item_by_retail_sku(retail_sku, branch, user, page_size=10, page=1):
 
     # Structure final response
     item_details = []
+    warehouse = frappe.db.get_value("POS Profile", branch + ' Operators', 'warehouse')
 
     for item in items:
         barcodes = [{"Barcode": code} for code in item.barcodes.split(", ")] if item.barcodes else []
@@ -1195,6 +1200,7 @@ def get_item_by_retail_sku(retail_sku, branch, user, page_size=10, page=1):
         sort_orders_index = {name: index for index, name in enumerate(sorted_order)}
         branches = item.branches.values()
         item.branches = sorted(branches, key=lambda x:  sort_orders_index.get(x.get("DisplayName"), len(sorted_order)))
+        on_order = get_on_order_quantity(item.item_code, warehouse)
 
         item_details.append({
             "Sku": item.item_code,
@@ -1202,6 +1208,7 @@ def get_item_by_retail_sku(retail_sku, branch, user, page_size=10, page=1):
             "RetailSku": item.ifw_retailskusuffix,
             "Categories": [],
             "Comment": "",
+            "OnOrderQty": on_order,
             "TemplateId": item.variant_of or "",
             "ImageUrl": item.image or "",
             "Brand": item.brand or "",
@@ -1223,6 +1230,17 @@ def get_item_by_retail_sku(retail_sku, branch, user, page_size=10, page=1):
         "Items": item_details
     })
 
+def get_on_order_quantity(item_code, warehouse):
+    po_items = frappe.db.get_all("Purchase Order Item", filters={
+        "item_code": item_code,
+        "warehouse": warehouse,
+        "parenttype": "Purchase Order",
+    }, fields=["sum(qty) as total_qty", "sum(received_qty) as total_received"])
+
+    if po_items and po_items[0].total_qty and po_items[0].total_received is not None:
+        return int(po_items[0].total_qty - po_items[0].total_received)
+    
+    return 0
 
 @frappe.whitelist()
 def get_item_by_retail_sku_single(retail_sku, branch):

--- a/metactical/custom_scripts/utils/pos_api.py
+++ b/metactical/custom_scripts/utils/pos_api.py
@@ -125,12 +125,12 @@ def receive_pos_data(*args, **kwargs):
                 sales_order=sales_order.name
             )
 
-        auto_logout = frappe.db.get_value("POS Profile", form_data["POSProfile"] + ' Operators', "auto_logout_after_transaction")
+        # auto_logout = frappe.db.get_value("POS Profile", form_data["POSProfile"] + ' Operators', "auto_logout_after_transaction")
         frappe.response["Status"] = "200"
         frappe.response["InvoiceId"] = sales_order.name
         frappe.response["Message"] = []
         frappe.response["Total"] = float(sales_order.grand_total)
-        frappe.response["AutoLogout"] = True if auto_logout else False
+        # frappe.response["AutoLogout"] = True if auto_logout else False
             
     except Exception as e:
         frappe.log_error(title='Receive POS Data Error', message=frappe.get_traceback())
@@ -906,14 +906,14 @@ def create_return(*args, **kwargs):
             frappe.response["Message"] = str(e)
     
     total = round(sales_return.grand_total + total_restock_fee, 2)
-    auto_logout = frappe.db.get_value("POS Profile", form_data["POSProfile"] + ' Operators', "auto_logout_after_transaction")
+    # auto_logout = frappe.db.get_value("POS Profile", form_data["POSProfile"] + ' Operators', "auto_logout_after_transaction")
     frappe.response["Status"] = 200
     frappe.response["Message"] = ""
     frappe.response["CouponCode"] = gift_card.coupon_code if gift_card else None
     frappe.response["SalesReturn"] = sales_return.name
     frappe.response["Total"] = total
     frappe.response["TotalAfterRestockFee"] = total
-    frappe.response["AutoLogout"] = True if auto_logout else False
+    # frappe.response["AutoLogout"] = True if auto_logout else False
     frappe.db.commit()
     
 def create_restock_invoice(total_restock_fee, sales_return, form_data):

--- a/metactical/hooks.py
+++ b/metactical/hooks.py
@@ -852,8 +852,7 @@ fixtures = [{
 			"Item-neb_paypal_restricted",
 			"Item-neb_airship_restricted",
 			"Employee-short_code",
-			"Item-last_pinged_on",
-			"POS Profile-auto_logout_after_transaction"
+			"Item-last_pinged_on"
 		]]]
 	},
 	{

--- a/metactical/hooks.py
+++ b/metactical/hooks.py
@@ -852,7 +852,8 @@ fixtures = [{
 			"Item-neb_paypal_restricted",
 			"Item-neb_airship_restricted",
 			"Employee-short_code",
-			"Item-last_pinged_on"
+			"Item-last_pinged_on",
+			"POS Profile-auto_logout_after_transaction"
 		]]]
 	},
 	{


### PR DESCRIPTION
This pull request introduces improvements to item data handling, barcode validation, and POS API responses, with a focus on enriching item information and ensuring barcode data consistency. The most significant changes are grouped below.

**Item Data Enrichment in POS API:**

* The `get_item_by_retail_sku` function now retrieves and returns additional fields for each item, including `asi_item_class`, `ifw_location`, and the calculated "OnOrderQty" (pending purchase order quantities for the item in the warehouse). This provides more comprehensive item details in POS responses. [[1]](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baL1087-R1091) [[2]](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baR1203-R1213) [[3]](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baR1235-R1261)
* Added a helper function `get_on_order_quantity` to calculate the quantity of items on order but not yet received, improving inventory visibility in POS operations.

**Barcode Validation and Assignment:**

* Introduced a new method `validate_barcodes` in `purchase_receipt.py` to ensure every item in a purchase receipt has an assigned barcode, fetching it from the `Item Barcode` table if missing. This helps maintain data integrity for purchased items.

**Address Data Handling:**

* In `orders_api.py`, the address creation logic now conditionally includes the `ifw_last_name` field, ensuring robustness when the last name is not present in the input data.

**POS API Response Adjustments (Commented Out):**

* Added (but commented out) logic to retrieve and return the `auto_logout_after_transaction` setting from the POS profile in both sales and return flows, preparing for potential future enhancements to session management. [[1]](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baR128-R133) [[2]](diffhunk://#diff-06e50ba0e4bfd1c86dd29cedb9cc24e7a41558636abccf4c1447beb9e66c62baR909-R916)