### PR TITLE
Fix: update for supplier cost in sales reports

### DIFF
--- a/metactical/metactical/report/dead_stock_report/dead_stock_report.py
+++ b/metactical/metactical/report/dead_stock_report/dead_stock_report.py
@@ -426,7 +426,7 @@ def get_open_po_qty(item,supplier):
 def get_item_details(item, price_list, list_type="Selling",  supplier=None):
 	cond = " and selling = 1"
 	
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("""select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}'
@@ -454,7 +454,7 @@ def get_item_details(item, price_list, list_type="Selling",  supplier=None):
 @frappe.whitelist()
 def get_cost_details(item, list_type="Buying",  supplier=None):
 	
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/dead_stock_report_v2/dead_stock_report_v2.py
+++ b/metactical/metactical/report/dead_stock_report_v2/dead_stock_report_v2.py
@@ -430,7 +430,7 @@ def get_open_po_qty(item,supplier):
 def get_item_details(item, price_list, list_type="Selling",  supplier=None):
 	cond = " and selling = 1"
 	
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("""select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}'
@@ -458,7 +458,7 @@ def get_item_details(item, price_list, list_type="Selling",  supplier=None):
 @frappe.whitelist()
 def get_cost_details(item, list_type="Buying",  supplier=None):
 	
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/detailed_sales_report_v1/detailed_sales_report_v1.py
+++ b/metactical/metactical/report/detailed_sales_report_v1/detailed_sales_report_v1.py
@@ -1331,7 +1331,7 @@ def get_item_details(item, list_type="Selling", supplier=None):
 		frappe.throw("Please set a default price list in stock Settings")
 
 	cond = "and price_list = '{}' and selling = 1".format(price_list)
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql(f"""select price_list_rate from `tabItem Price`

--- a/metactical/metactical/report/sales_report___for_admins/sales_report___for_admins.py
+++ b/metactical/metactical/report/sales_report___for_admins/sales_report___for_admins.py
@@ -762,7 +762,7 @@ def get_item_details(item, list_type="Selling", supplier=None):
 	if price_list is None or price_list  == "":
 		frappe.throw("Please set a default price list in stock Settings")
 	cond = "and price_list = '{}' and selling = 1".format(price_list)
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` \

--- a/metactical/metactical/report/sales_report___full_v3/sales_report___full_v3.py
+++ b/metactical/metactical/report/sales_report___full_v3/sales_report___full_v3.py
@@ -506,7 +506,7 @@ def get_open_po_qty(item,supplier):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling", supplier=None):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report___full_v4/sales_report___full_v4.py
+++ b/metactical/metactical/report/sales_report___full_v4/sales_report___full_v4.py
@@ -516,7 +516,7 @@ def get_open_po_qty(item,supplier):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling", supplier=None):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report___full_v5/sales_report___full_v5.py
+++ b/metactical/metactical/report/sales_report___full_v5/sales_report___full_v5.py
@@ -577,7 +577,7 @@ def get_open_po_qty(item,supplier):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling", supplier=None):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report___full_v6/sales_report___full_v6.py
+++ b/metactical/metactical/report/sales_report___full_v6/sales_report___full_v6.py
@@ -596,7 +596,7 @@ def get_open_po_qty(item,supplier):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling", supplier=None):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report___full_v7/sales_report___full_v7.py
+++ b/metactical/metactical/report/sales_report___full_v7/sales_report___full_v7.py
@@ -617,7 +617,7 @@ def get_open_po_qty(item,supplier):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling", supplier=None):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report___full_v8/sales_report___full_v8.py
+++ b/metactical/metactical/report/sales_report___full_v8/sales_report___full_v8.py
@@ -24,7 +24,7 @@ def execute(filters=None):
 	
 	#Get US data
 	us_data = {}
-	us_data = get_us_data(filters)
+	# us_data = get_us_data(filters)
 	
 	# details = get_details(conditions,filters)
 	combo_dict = {}
@@ -205,6 +205,13 @@ def get_column(filters,conditions):
 				"fieldtype": "Data",
 				"width": 150,
 			},
+   
+			{
+				"label": _("Cost"),
+				"fieldname": "item_cost",
+				"fieldtype": "Currency",
+				"width": 100,
+			},
 			{
 				"label": "QtyToOrderd",
 				"fieldname": "qty_to_order",
@@ -339,12 +346,6 @@ def get_column(filters,conditions):
 				"fieldname": "date_last_received",
 				"fieldtype": "DateTime",
 				"width": 200,
-			},
-			{
-				"label": _("Cost"),
-				"fieldname": "item_cost",
-				"fieldtype": "Currency",
-				"width": 100,
 			},
 			{
 				"label": _("Suplier SKU"),
@@ -794,7 +795,7 @@ def get_item_details(item, list_type="Selling", supplier=None):
 	if price_list is None or price_list  == "":
 		frappe.throw("Please set a default price list in stock Settings")
 	cond = "and price_list = '{}' and selling = 1".format(price_list)
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` \

--- a/metactical/metactical/report/sales_report___full_v8/sales_report___full_v8.py
+++ b/metactical/metactical/report/sales_report___full_v8/sales_report___full_v8.py
@@ -24,7 +24,7 @@ def execute(filters=None):
 	
 	#Get US data
 	us_data = {}
-	# us_data = get_us_data(filters)
+	us_data = get_us_data(filters)
 	
 	# details = get_details(conditions,filters)
 	combo_dict = {}
@@ -205,13 +205,6 @@ def get_column(filters,conditions):
 				"fieldtype": "Data",
 				"width": 150,
 			},
-   
-			{
-				"label": _("Cost"),
-				"fieldname": "item_cost",
-				"fieldtype": "Currency",
-				"width": 100,
-			},
 			{
 				"label": "QtyToOrderd",
 				"fieldname": "qty_to_order",
@@ -346,6 +339,12 @@ def get_column(filters,conditions):
 				"fieldname": "date_last_received",
 				"fieldtype": "DateTime",
 				"width": 200,
+			},
+   			{
+				"label": _("Cost"),
+				"fieldname": "item_cost",
+				"fieldtype": "Currency",
+				"width": 100,
 			},
 			{
 				"label": _("Suplier SKU"),

--- a/metactical/metactical/report/sales_report___stores/sales_report___stores.py
+++ b/metactical/metactical/report/sales_report___stores/sales_report___stores.py
@@ -149,7 +149,7 @@ def get_conditions(filters, sales_order=None):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling"):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report___stores_restocking_v1/sales_report___stores_restocking_v1.py
+++ b/metactical/metactical/report/sales_report___stores_restocking_v1/sales_report___stores_restocking_v1.py
@@ -211,7 +211,7 @@ def get_conditions(filters, sales_order=None):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling"):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report___stores_v3/sales_report___stores_v3.py
+++ b/metactical/metactical/report/sales_report___stores_v3/sales_report___stores_v3.py
@@ -183,7 +183,7 @@ def get_conditions(filters, sales_order=None):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling"):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report___stores_v4/sales_report___stores_v4.py
+++ b/metactical/metactical/report/sales_report___stores_v4/sales_report___stores_v4.py
@@ -231,7 +231,7 @@ def get_conditions(filters, sales_order=None):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling"):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report___usa/sales_report___usa.py
+++ b/metactical/metactical/report/sales_report___usa/sales_report___usa.py
@@ -627,7 +627,7 @@ def get_open_po_qty(item,supplier, warehouse=None):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling", supplier=None):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report_rasusa___full_v1/sales_report_rasusa___full_v1.py
+++ b/metactical/metactical/report/sales_report_rasusa___full_v1/sales_report_rasusa___full_v1.py
@@ -520,7 +520,7 @@ def get_open_po_qty(item,supplier):
 @frappe.whitelist()
 def get_item_details(item, list_type="Selling", supplier=None):
 	cond = " and selling = 1"
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` where '{}' between valid_from and valid_upto and item_code = '{}' {} limit 1".format(date, item, cond))

--- a/metactical/metactical/report/sales_report_with_item_class_suggest/sales_report_with_item_class_suggest.py
+++ b/metactical/metactical/report/sales_report_with_item_class_suggest/sales_report_with_item_class_suggest.py
@@ -1399,7 +1399,7 @@ def get_item_details(item, list_type="Selling", supplier=None):
 	if price_list is None or price_list  == "":
 		frappe.throw("Please set a default price list in stock Settings")
 	cond = "and price_list = '{}' and selling = 1".format(price_list)
-	if list_type == "Buying": cond= " and buying = 1"
+	if list_type == "Buying": cond= " and buying = 1 and price_list like 'SUP%'"
 	rate = 0
 	date = frappe.utils.nowdate()
 	r = frappe.db.sql("select price_list_rate from `tabItem Price` \


### PR DESCRIPTION
This pull request updates the logic for fetching item price rates in various sales and stock report modules. The main change is that when retrieving buying prices, the SQL condition now requires the `price_list` to match supplier price lists (i.e., those starting with `'SUP%'`). This ensures that only supplier-specific price lists are considered for buying price queries, improving the accuracy of cost calculations.

**Report logic updates:**

* Updated the buying price retrieval condition in the `get_item_details` and `get_cost_details` functions across multiple report files to include `and price_list like 'SUP%'`, ensuring only supplier price lists are used for buying price queries. [[1]](diffhunk://#diff-7a9d2268fa40d1c04547a6d880a2e17b06f7b7421d83b244522af8306d678ab0L429-R429) [[2]](diffhunk://#diff-7a9d2268fa40d1c04547a6d880a2e17b06f7b7421d83b244522af8306d678ab0L457-R457) [[3]](diffhunk://#diff-3438aa088b6581c27577f9f00be90bd5e0c0a1b4939e26f0bb7f0e448f945f7cL433-R433) [[4]](diffhunk://#diff-3438aa088b6581c27577f9f00be90bd5e0c0a1b4939e26f0bb7f0e448f945f7cL461-R461) [[5]](diffhunk://#diff-6b71ab12b5309f9dae1bf9d26ca4cdfad553209bcc6275304ce7184671f50b7aL1334-R1334) [[6]](diffhunk://#diff-58b52175c255745d4ab853a6994133002252c3157d8c25e31f15b06de590f89dL765-R765) [[7]](diffhunk://#diff-beed9bc7f713281037bd58b31c7796e776bb94126af88d02392f6d38795d3131L509-R509) [[8]](diffhunk://#diff-2969720ff48035c92a7649d3ebc0ef80014c6d0ae8e27efadb3e5de14e7ab010L519-R519) [[9]](diffhunk://#diff-1eb7acbef7ab8448f75b6b2557ba19bb55d2ee493dc3c6021e9825aa5a3a66e9L580-R580) [[10]](diffhunk://#diff-af52b42cbe505a671e8aba907baf00d1d0f8fc85c24c702ff88ad04f51e35f01L599-R599) [[11]](diffhunk://#diff-f4d70b528024cdb22c416f31db1f177d8039cbceb782d4bf27f571fb6caef0a2L620-R620) [[12]](diffhunk://#diff-b32aef610518c60b97995868d1c95974ee1b68b25beab8d41df2905b8b2a29d9L797-R797) [[13]](diffhunk://#diff-611ed402d74cc0a1fcc2b66eb6c27b1e28030f946b3515a577a1eb253db9e636L152-R152) [[14]](diffhunk://#diff-5ead3a06742d9e3fdd2e201bfbe788898f4328952faaddf82b5d6086d7c8d5d0L214-R214) [[15]](diffhunk://#diff-4b001429f0f7f586d793829299eb5c50061832cc56bf5cc3f13b6f6d3435c174L186-R186) [[16]](diffhunk://#diff-20e1fe18955b9b0b010b116a1fb6aa05bd8cdf5c0a9300ca07ae56b959834364L234-R234) [[17]](diffhunk://#diff-66ddb47f5134db4f4eec233164c847dc6b57557b1f83c86d0eb32ac502dd84c4L630-R630) [[18]](diffhunk://#diff-97ed9fb1133cdbbfa269f84a92f3e2ab9dfa949b9622bd1def8abe8cd49c4e00L523-R523) [[19]](diffhunk://#diff-d5d3090c61ec0862c271b688df168ac3714b65f69f272bcbd7ccc08821360123L1402-R1402)

This change is applied consistently across all relevant report scripts to standardize the way buying prices are filtered and retrieved.