### PR TITLE
feat: validation of store address for in store pick orders

### DIFF
--- a/metactical/custom_scripts/delivery_note/delivery_note.py
+++ b/metactical/custom_scripts/delivery_note/delivery_note.py
@@ -23,6 +23,18 @@ class DeliveryNoteCustom(DeliveryNote):
 		else:
 			super().save()
 
+	def before_save(self):		
+		# Metactical Customization: check in store pickups
+		sales_order = self.items[0].against_sales_order if self.items else None
+		if sales_order:
+			store_pickup = frappe.db.get_value("Sales Order", sales_order, "ifw_store_pickup")
+			if store_pickup:
+				shipment_settings = frappe.get_single("Shipment Settings")
+				store_addresses = [addr.address.strip() for addr in shipment_settings.store_address]
+
+				if self.shipping_address_name not in store_addresses:
+					frappe.throw(_("For store pickup orders, the shipping address must be one of the store addresses. Please update the shipping address."))
+
 	def on_update(self):
 		if self.docstatus == 0:
 			create_shipstation_orders(self.name)

--- a/metactical/fixtures/property_setter.json
+++ b/metactical/fixtures/property_setter.json
@@ -8871,13 +8871,13 @@
   "doctype_or_field": "DocField",
   "field_name": "valuation_rate",
   "is_system_generated": 0,
-  "modified": "2025-09-24 02:38:39.830051",
+  "modified": "2025-10-10 02:38:39.830051",
   "module": null,
   "name": "Stock Reconciliation Item-valuation_rate-permlevel",
   "property": "permlevel",
   "property_type": "Int",
   "row_name": null,
-  "value": "3"
+  "value": "0"
  },
  {
   "default_value": null,

--- a/metactical/metactical/doctype/shipment_settings/shipment_settings.json
+++ b/metactical/metactical/doctype/shipment_settings/shipment_settings.json
@@ -14,7 +14,9 @@
   "disable_automatic_print",
   "email_notifications_section",
   "send_email_to_customers",
-  "email_settings"
+  "email_settings",
+  "section_break_nqddh",
+  "store_address"
  ],
  "fields": [
   {
@@ -66,12 +68,22 @@
    "fieldtype": "Table",
    "label": "Email Settings",
    "options": "Shipment Notification Settings"
+  },
+  {
+   "fieldname": "section_break_nqddh",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "store_address",
+   "fieldtype": "Table",
+   "label": "Store Addresses",
+   "options": "Store Address"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-29 07:33:15.886093",
+ "modified": "2025-10-09 10:55:09.125955",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Shipment Settings",

--- a/metactical/metactical/doctype/store_address/store_address.json
+++ b/metactical/metactical/doctype/store_address/store_address.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-10-09 10:48:41.135920",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "address"
+ ],
+ "fields": [
+  {
+   "fieldname": "address",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Address",
+   "options": "Address",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-10-10 07:02:10.076231",
+ "modified_by": "Administrator",
+ "module": "Metactical",
+ "name": "Store Address",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/metactical/metactical/doctype/store_address/store_address.py
+++ b/metactical/metactical/doctype/store_address/store_address.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2025, Techlift Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class StoreAddress(Document):
+	pass


### PR DESCRIPTION
This pull request introduces a new feature to support store pickup functionality in the delivery note workflow. The main changes include enforcing store address validation for store pickup orders, adding a new `Store Address` child table to shipment settings, and updating permissions for valuation rate in stock reconciliation items.

**Store Pickup Feature:**

* Added a new DocType `Store Address` (`store_address.json`, `store_address.py`) to represent valid store addresses for pickups. [[1]](diffhunk://#diff-734711611523c3086acf20d626eafaeca4c22bd9b61f079a79778c288694e0fcR1-R33) [[2]](diffhunk://#diff-5826d69745543b3963bf1c6903cec79a57012b25207b0f219a8939fe54a8f417R1-R8)
* Extended the `Shipment Settings` DocType to include a `store_address` table field and related section break, allowing administrators to configure store addresses. [[1]](diffhunk://#diff-3937e4e702d1df8792ef6878d49255f69e9a456222d2ff372d9eabb048c1f285L17-R19) [[2]](diffhunk://#diff-3937e4e702d1df8792ef6878d49255f69e9a456222d2ff372d9eabb048c1f285R71-R86)

**Validation Logic:**

* Implemented a `before_save` hook in `delivery_note.py` to ensure that, for store pickup sales orders, the shipping address matches one of the configured store addresses; otherwise, the save is blocked.

**Permissions Update:**

* Changed the permission level for the `valuation_rate` field in `Stock Reconciliation Item` from 3 to 0, making it accessible at the base permission level.