### PR TITLE
Metactical workspace updates, inventory output fix for sales order cancellation

### DIFF
--- a/metactical/custom_scripts/sales_order/sales_order.py
+++ b/metactical/custom_scripts/sales_order/sales_order.py
@@ -86,7 +86,7 @@ class SalesOrderCustom(SalesOrder):
 
 		# Metactical Customization: Added
 		for item in self.items:
-			frappe.enqueue(update_item_inventory_output, item_code=item.item_code, voucher_type="Sales Order", queue='default')
+			update_item_inventory_output(item_code=item.item_code, voucher_type="Sales Order")
 
 	def on_update_after_submit(self):
 		super().on_update_after_submit()

--- a/metactical/metactical/workspace/metactical/metactical.json
+++ b/metactical/metactical/workspace/metactical/metactical.json
@@ -153,125 +153,6 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Stock Management",
-   "link_count": 11,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Cycle Count",
-   "link_count": 0,
-   "link_to": "Cycle Count",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Cycle Count V2",
-   "link_count": 0,
-   "link_to": "Cycle Count V2",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Stock Entry User Permissions",
-   "link_count": 0,
-   "link_to": "Stock Entry User Permissions",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "STE Packing Slip",
-   "link_count": 0,
-   "link_to": "STE Packing Slip",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Report - Stock Reconciliation Report",
-   "link_count": 0,
-   "link_to": "Stock Reconciliation Report",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Report - Stock Summary With STE Info",
-   "link_count": 0,
-   "link_to": "Stock Summary With STE Info",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Reprot - STE Draft Report",
-   "link_count": 0,
-   "link_to": "STE Draft Report",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Report - Stock Balance With Purchase Rates",
-   "link_count": 0,
-   "link_to": "Stock Balance With Purchase Rates",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Report - Dead Stock Report V2",
-   "link_count": 0,
-   "link_to": "Dead Stock Report V2",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Report - Unreconciled Stock Report",
-   "link_count": 0,
-   "link_to": "Warehouse Stock Report",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Report - Stock Balance Totals - Purchase Rates",
-   "link_count": 0,
-   "link_to": "Stock Balance Totals - Purchase Rates",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Reorder Qty From Excel",
    "link_count": 0,
    "link_to": "Reorder Qty From Excel",
@@ -1095,9 +976,138 @@
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Stock Management",
+   "link_count": 12,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Cycle Count",
+   "link_count": 0,
+   "link_to": "Cycle Count",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Cycle Count V2",
+   "link_count": 0,
+   "link_to": "Cycle Count V2",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Stock Entry User Permissions",
+   "link_count": 0,
+   "link_to": "Stock Entry User Permissions",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "STE Packing Slip",
+   "link_count": 0,
+   "link_to": "STE Packing Slip",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Report - Stock Reconciliation Report",
+   "link_count": 0,
+   "link_to": "Stock Reconciliation Report",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Report - Stock Summary With STE Info",
+   "link_count": 0,
+   "link_to": "Stock Summary With STE Info",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Reprot - STE Draft Report",
+   "link_count": 0,
+   "link_to": "STE Draft Report",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Report - Stock Balance With Purchase Rates",
+   "link_count": 0,
+   "link_to": "Stock Balance With Purchase Rates",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Report - Dead Stock Report V2",
+   "link_count": 0,
+   "link_to": "Dead Stock Report V2",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Report - Unreconciled Stock Report",
+   "link_count": 0,
+   "link_to": "Warehouse Stock Report",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Report - Stock Balance Totals - Purchase Rates",
+   "link_count": 0,
+   "link_to": "Stock Balance Totals - Purchase Rates",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Reorder Qty From Excel",
+   "link_count": 0,
+   "link_to": "Reorder Qty From Excel",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2025-12-23 07:22:31.420449",
+ "modified": "2025-12-23 07:26:36.708218",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Metactical",

--- a/metactical/metactical/workspace/metactical/metactical.json
+++ b/metactical/metactical/workspace/metactical/metactical.json
@@ -272,6 +272,26 @@
   {
    "hidden": 0,
    "is_query_report": 0,
+   "label": "Reorder Qty From Excel",
+   "link_count": 0,
+   "link_to": "Reorder Qty From Excel",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Sales Report - Stores Restocking V1",
+   "link_count": 0,
+   "link_to": "Sales Report - Stores Restocking V1",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
    "label": "Pick Lists and Packing",
    "link_count": 12,
    "link_type": "DocType",
@@ -962,35 +982,6 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Warehouse",
-   "link_count": 2,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Report - Sales Report by Location",
-   "link_count": 0,
-   "link_to": "Sales Report by Location",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Report - Item Locations",
-   "link_count": 0,
-   "link_to": "Item Locations",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Accounting",
    "link_count": 3,
    "link_type": "DocType",
@@ -1065,9 +1056,48 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Warehouse",
+   "link_count": 3,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Report - Sales Report by Location",
+   "link_count": 0,
+   "link_to": "Sales Report by Location",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Report - Item Locations",
+   "link_count": 0,
+   "link_to": "Item Locations",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Report -  Stores Restocking V1",
+   "link_count": 0,
+   "link_to": "Sales Report - Stores Restocking V1",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2025-09-07 02:24:32.864579",
+ "modified": "2025-12-23 07:22:31.420449",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Metactical",


### PR DESCRIPTION
This pull request includes two main types of changes: (1) a modification to how inventory updates are triggered on sales order cancellation, and (2) a significant reorganization and update of the workspace navigation in the `metactical.json` file. The workspace changes involve rearranging, adding, and removing various cards and links to better reflect current business needs.

**Workspace Navigation Updates:**

* Major reorganization of workspace sections in `metactical.json`, including moving, adding, and removing several cards and links for improved clarity and workflow. Notable changes include introducing new sections like "Accounting" and "Settings", adding new reports such as "QBO Import Report", and restoring previously removed links for stock and warehouse management. [[1]](diffhunk://#diff-17eb6c5ff983a7889662d05070c46428e92b826e114700a9463887bc2a6c1b00L156-R168) [[2]](diffhunk://#diff-17eb6c5ff983a7889662d05070c46428e92b826e114700a9463887bc2a6c1b00L965-R1110)

**Functionality Change in Sales Order Script:**

* Changed the `on_cancel` method in `sales_order.py` to call `update_item_inventory_output` synchronously for each item instead of enqueuing it as a background task, which may impact performance but ensures immediate execution.