### PR TITLE
end of day report - v5 improvements

### DIFF
--- a/metactical/metactical/report/end_of_day_report___v5/end_of_day_report___v5.py
+++ b/metactical/metactical/report/end_of_day_report___v5/end_of_day_report___v5.py
@@ -22,6 +22,10 @@ def execute(filters=None):
 		data.append({"Location": "USA"})
 		data.extend(us_data)
 		
+	for row in data:
+		if row.get("eod_link"):
+			row["location"] = row.get("eod_link")
+  
 	return columns, data
 	
 def get_columns(filters):
@@ -49,6 +53,13 @@ def get_columns(filters):
 			"fieldname": "difference",
 			"fieldtype": "Currency",
 			"label": "Difference",
+			"width": 120,
+			"options": "Currency",
+		},
+		{
+			"fieldname": "notes",
+			"fieldtype": "Data",
+			"label": "Note",
 			"width": 120,
 			"options": "Currency",
 		},
@@ -274,11 +285,16 @@ def get_website_stores_data(filters, location, sources):
 					"cash_sales": cash_sales
 				})
 	
-				end_of_day_difference = frappe.db.get_value("End of Day Closing", {"lead_source": source.name, "closing_date": filters.date}, "mop_total_difference")		
-				if end_of_day_difference is not None:
+				end_of_day_closing = frappe.db.get_value("End of Day Closing", {"lead_source": source.name, "closing_date": filters.date}, ["mop_total_difference", "closing_notes", "name"], as_dict=1, order_by="creation desc")	
+				if end_of_day_closing is not None:
 					row.update({
-						"difference": end_of_day_difference
-					})		
+						"difference": end_of_day_closing.mop_total_difference,
+						"notes": end_of_day_closing.closing_notes
+					})
+     
+					row.update({
+						"eod_link": "<a href='/app/end-of-day-closing/{0}' target='_blank'>{1}</a>".format(end_of_day_closing.name, row.get("location"))
+					})
 
 
 			#Add row to data

--- a/metactical/metactical/report/end_of_day_report___v5/end_of_day_report___v5.py
+++ b/metactical/metactical/report/end_of_day_report___v5/end_of_day_report___v5.py
@@ -290,9 +290,6 @@ def get_website_stores_data(filters, location, sources):
 					row.update({
 						"difference": end_of_day_closing.mop_total_difference,
 						"notes": end_of_day_closing.closing_notes
-					})
-     
-					row.update({
 						"eod_link": "<a href='/app/end-of-day-closing/{0}' target='_blank'>{1}</a>".format(end_of_day_closing.name, row.get("location"))
 					})
 

--- a/metactical/metactical/report/end_of_day_report___v5/end_of_day_report___v5.py
+++ b/metactical/metactical/report/end_of_day_report___v5/end_of_day_report___v5.py
@@ -289,7 +289,7 @@ def get_website_stores_data(filters, location, sources):
 				if end_of_day_closing is not None:
 					row.update({
 						"difference": end_of_day_closing.mop_total_difference,
-						"notes": end_of_day_closing.closing_notes
+						"notes": end_of_day_closing.closing_notes,
 						"eod_link": "<a href='/app/end-of-day-closing/{0}' target='_blank'>{1}</a>".format(end_of_day_closing.name, row.get("location"))
 					})
 


### PR DESCRIPTION
This pull request enhances the End of Day Report by adding a new "Note" column, displaying additional information from the "End of Day Closing" document, and providing direct links to related records in the report. The changes improve the report's usefulness and navigation for end users.

**Report Enhancements:**

* Added a new "Note" column to the report, allowing display of closing notes from the "End of Day Closing" document.
* Fetched and displayed additional fields from "End of Day Closing" (including `closing_notes` and the document's `name`) for each row, and included a clickable link (`eod_link`) to the related document.
* Updated each report row to include the `eod_link` value in the `location` field if it exists, making it easier for users to navigate to the relevant "End of Day Closing" record directly from the report.