### PR TITLE
fix: round price_list_rate to two decimal places in item verification

### DIFF
--- a/metactical/custom_scripts/utils/orders_api.py
+++ b/metactical/custom_scripts/utils/orders_api.py
@@ -927,7 +927,7 @@ def verify_items(parsedContent, sales_order):
 
 	so_item_row = {}
 	for i, item in enumerate(sales_order.items):
-		if item.item_code != items[i].item_code or item.qty != items[i].qty or item.price_list_rate != items[i].price_list_rate:
+		if item.item_code != items[i].item_code or item.qty != items[i].qty or item.price_list_rate != round(items[i].price_list_rate, 2):
 			items_updated = True
 
 		so_item_row[item.item_code] = item


### PR DESCRIPTION
This pull request makes a small change to the `verify_items` function in `orders_api.py` to improve the accuracy of item price comparisons by rounding the `price_list_rate` to two decimal places before comparing it.

* Improved price comparison logic by rounding `items[i].price_list_rate` to two decimal places before comparing with `item.price_list_rate` in the `verify_items` function (`orders_api.py`).