### PR TITLE
use system time for pos opening and end of day closing

### DIFF
--- a/metactical/custom_scripts/utils/closing_api.py
+++ b/metactical/custom_scripts/utils/closing_api.py
@@ -47,7 +47,7 @@ def create_closing_entry(*args, **kwargs):
         end_of_day_closing.user = user
         end_of_day_closing.pos_profile = pos_profile
         end_of_day_closing.closing_date = closing_date
-        end_of_day_closing.closing_time = form_data.get("Time")
+        end_of_day_closing.closing_time = frappe.utils.nowtime()
         end_of_day_closing.company = pos_profile_doc.company
         end_of_day_closing.cash_float = form_data.get("CashFloat")
         end_of_day_closing.subtracted_float = -form_data.get("CashFloat", 0)

--- a/metactical/custom_scripts/utils/opening_api.py
+++ b/metactical/custom_scripts/utils/opening_api.py
@@ -105,10 +105,10 @@ def create_opening_entry(*args, **kwargs):
         frappe.response["coins_total"] = opening.coins_total
     except Exception as e:
         frappe.log_error(message=frappe.get_traceback(), title="POS - Error creating opening entry")
-        frappe.db.rollback()
         frappe.response["status"] = "error"
-        frappe.response["message"] = str(e)
-        
+        frappe.response["message"] = f"User {user} has no permission to create opening entry" if not str(e) else str(e)
+        frappe.db.rollback()
+
 def create_pos_api_log(form_data):
     """
     Create a log entry for the POS API call.

--- a/metactical/custom_scripts/utils/opening_api.py
+++ b/metactical/custom_scripts/utils/opening_api.py
@@ -44,7 +44,7 @@ def create_opening_entry(*args, **kwargs):
         opening.user = user
         opening.pos_profile = pos_profile
         opening.opening_date = opening_date
-        opening.opening_time = form_data.get("Time")
+        opening.opening_time = frappe.utils.nowtime()
         opening.company = pos_profile_doc.company
         opening.cash_float = form_data.get("CashFloat")
         


### PR DESCRIPTION
This pull request updates the handling of opening and closing time fields in POS entry creation and improves error messaging for opening entries. The most important changes are:

**Time Handling Improvements:**
* The `opening_time` in `create_opening_entry` and `closing_time` in `create_closing_entry` are now set to the current server time using `frappe.utils.nowtime()` instead of relying on user-provided data. [[1]](diffhunk://#diff-29ddf5099724a97f097c92f8c81899913d710d89a9cd6f9afda17d3093b5b402L47-R47) [[2]](diffhunk://#diff-9c007fdba81d604d9bc00b8f99a0bc5664eaf6245ed1b8ac893c1fe809c1e7d0L50-R50)

**Error Handling Enhancements:**
* The error message for failures in `create_opening_entry` now provides a more informative response, specifically indicating when a user lacks permission to create an opening entry. The `frappe.db.rollback()` call is moved to ensure it always runs after setting the response.