### PR TITLE
fix: add grand total to order details and adjust discount amount if necessary

### DIFF
--- a/metactical/custom_scripts/utils/orders_api.py
+++ b/metactical/custom_scripts/utils/orders_api.py
@@ -254,6 +254,7 @@ def get_order_detail(parsedContent, province, country, company, shipping_item, f
 		"source": parsedContent['publisher_site'],
 		"taxes_and_charges": get_taxes_and_charges(province, country, company, parsedContent['publisher_site']),
 		"currency": parsedContent['grandTotalAmount']['Currency']["isoCode"],
+		"grand_total": parsedContent['grandTotal'],
 		"company": company,
 		"shipping_item": shipping_item,
 		"far_distance_shipping_item": far_distance_shipping_item,
@@ -411,7 +412,7 @@ def create_order(order_detail, customer, shipping_address_doc, billing_address_d
 		"customer_address": billing_address_doc.name,
 		"ifw_store_pickup": order_detail["ifw_store_pickup"],
 		"discount_amount": order_detail["total_discount_amount"],
-		"ignore_pricing_rule": 1,  # Ignore pricing rules for this order
+		"ignore_pricing_rule": 1,
 		"is_rush": is_rush(items),
 		"apply_discount_on": "Net Total"
 	}
@@ -432,6 +433,14 @@ def create_order(order_detail, customer, shipping_address_doc, billing_address_d
 	# set the missing values for the order and submit it if the gateway is not "interacetransfer"
 	new_order.set_missing_values()	
 	new_order.save()
+ 
+	difference = 0
+	if "grand_total" in order_detail and order_detail["grand_total"] < new_order.grand_total:
+		difference = new_order.grand_total - order_detail["grand_total"]
+		new_order.discount_amount += difference
+		new_order.save()
+		logger.error(f"Adjusted discount amount by {difference} for order {new_order.name} to match grand total from RMQ.")
+ 
 	logger.error(f"New Order Created: {new_order.name} shipping address: {shipping_address_doc.name}, billing address: {billing_address_doc.name}")
 	frappe.db.commit()
 	


### PR DESCRIPTION
This pull request updates the order creation logic to ensure the grand total in the system matches the expected value from the incoming order data. The main change is the introduction of a check and adjustment for discrepancies between the provided and calculated grand totals, improving data consistency and error tracking.

Order total consistency and adjustment:

* Added a `grand_total` field to the order detail dictionary, sourced from the parsed external order data, to track the expected order total throughout the process.
* After saving a new order, added logic to compare the provided `grand_total` with the system-calculated value. If the system's grand total is higher, the code increases the order's discount amount to compensate and logs the adjustment for traceability.

Other minor changes:

* Removed a comment from the `ignore_pricing_rule` assignment for clarity, but retained the functionality.