### PR TITLE
Doctype to set filters and tags in order to assign tags automatically to Items

### DIFF
--- a/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.js
+++ b/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, Storebuilder Commerce Inc and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Item Tag Assignment", {
+	refresh(frm) {
+
+	},
+    setup: function(frm) {
+		frm.get_field("conditions").$wrapper.html(
+			`<p><b>${__("Total Items:")}  0</b></p>`
+		);
+
+		frappe.model.with_doctype("Item", () => {
+			filter_group = new frappe.ui.FilterGroup({
+				parent: frm.get_field("conditions").$wrapper,
+				doctype: "Item",
+				on_change: () => {
+					if (!filter_group.get_filters().length) {
+						frm.get_field("conditions").$wrapper.html(
+							`<p><b>${__("Total Items:")}  0</b></p>`
+						);
+					}
+					else{
+						var total = frappe.db.count("Item", {
+							filters: frm.events.get_filters(filter_group)
+						})
+						
+						total.then((total) => {
+							frm.get_field("conditions").$wrapper.html(
+								`<p><b>${__("Total Items:")}  ${total}</b></p>`
+							);
+						});
+					}
+				},
+			});
+		});
+
+	},
+
+	get_filters(filter_group) {
+		return filter_group.get_filters().map((filter) => {
+			return filter.slice(0, 4);
+		});
+	}
+});

--- a/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.js
+++ b/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.js
@@ -1,12 +1,28 @@
 // Copyright (c) 2026, Storebuilder Commerce Inc and contributors
 // For license information, please see license.txt
+var filter_group = null;
 
 frappe.ui.form.on("Item Tag Assignment", {
-	refresh(frm) {
-
-	},
-    setup: function(frm) {
-		frm.get_field("conditions").$wrapper.html(
+	refresh(frm) {   
+        var filters = JSON.parse(frm.doc.filters || "[]");
+    
+        filters && frappe.model.with_doctype("Item", () => {
+            // Clear existing filters before adding new ones
+            filter_group.clear_filters();
+            filter_group.add_filters_to_filter_group(filters);
+        });
+    
+        frappe.db.count("Item", {
+            filters: filters
+        }).then((total) => {
+            frm.get_field("filters_detail").$wrapper.html(
+                `<p><b>${__("Total Items:")}  ${total}</b></p>`
+            );
+        });
+    },
+    
+	setup: function(frm) {
+		frm.get_field("filters_detail").$wrapper.html(
 			`<p><b>${__("Total Items:")}  0</b></p>`
 		);
 
@@ -14,9 +30,10 @@ frappe.ui.form.on("Item Tag Assignment", {
 			filter_group = new frappe.ui.FilterGroup({
 				parent: frm.get_field("conditions").$wrapper,
 				doctype: "Item",
+                default_filters: '[["Item","name","=","2"],["Item","ifw_discontinued","=",1]]',
 				on_change: () => {
 					if (!filter_group.get_filters().length) {
-						frm.get_field("conditions").$wrapper.html(
+						frm.get_field("filters_detail").$wrapper.html(
 							`<p><b>${__("Total Items:")}  0</b></p>`
 						);
 					}
@@ -26,11 +43,13 @@ frappe.ui.form.on("Item Tag Assignment", {
 						})
 						
 						total.then((total) => {
-							frm.get_field("conditions").$wrapper.html(
+							frm.get_field("filters_detail").$wrapper.html(
 								`<p><b>${__("Total Items:")}  ${total}</b></p>`
 							);
 						});
 					}
+
+                    frm.set_value("filters", JSON.stringify(frm.events.get_filters(filter_group)));
 				},
 			});
 		});

--- a/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.json
+++ b/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.json
@@ -1,0 +1,71 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-02-02 03:38:10.423782",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "rule_name",
+  "section_break_whiv",
+  "conditions",
+  "column_break_hzgd",
+  "section_break_ezbx",
+  "tag"
+ ],
+ "fields": [
+  {
+   "fieldname": "rule_name",
+   "fieldtype": "Data",
+   "label": "Rule Name"
+  },
+  {
+   "fieldname": "conditions",
+   "fieldtype": "HTML",
+   "label": "Conditions"
+  },
+  {
+   "fieldname": "tag",
+   "fieldtype": "Data",
+   "label": "Tag"
+  },
+  {
+   "fieldname": "column_break_hzgd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_ezbx",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_whiv",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-02-02 03:48:34.839480",
+ "modified_by": "Administrator",
+ "module": "Metactical",
+ "name": "Item Tag Assignment",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.json
+++ b/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.json
@@ -1,22 +1,28 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:{rule_name}",
  "creation": "2026-02-02 03:38:10.423782",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "rule_name",
+  "column_break_ykyz",
+  "tag",
   "section_break_whiv",
   "conditions",
   "column_break_hzgd",
+  "filters",
   "section_break_ezbx",
-  "tag"
+  "filters_detail"
  ],
  "fields": [
   {
    "fieldname": "rule_name",
    "fieldtype": "Data",
-   "label": "Rule Name"
+   "in_list_view": 1,
+   "label": "Rule Name",
+   "reqd": 1
   },
   {
    "fieldname": "conditions",
@@ -25,8 +31,11 @@
   },
   {
    "fieldname": "tag",
-   "fieldtype": "Data",
-   "label": "Tag"
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Tag",
+   "options": "Tag",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_hzgd",
@@ -38,16 +47,32 @@
   },
   {
    "fieldname": "section_break_whiv",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Filters"
+  },
+  {
+   "fieldname": "filters_detail",
+   "fieldtype": "Data"
+  },
+  {
+   "fieldname": "filters",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_ykyz",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-02 03:48:34.839480",
+ "modified": "2026-02-02 11:03:25.572933",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Item Tag Assignment",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.py
+++ b/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2026, Storebuilder Commerce Inc and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class ItemTagAssignment(Document):
-	pass
+	def validate(self):
+		if not self.filters or self.filters == '[]':
+			frappe.throw("Please set filters")

--- a/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.py
+++ b/metactical/metactical/doctype/item_tag_assignment/item_tag_assignment.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Storebuilder Commerce Inc and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ItemTagAssignment(Document):
+	pass

--- a/metactical/metactical/doctype/item_tag_assignment/test_item_tag_assignment.py
+++ b/metactical/metactical/doctype/item_tag_assignment/test_item_tag_assignment.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Storebuilder Commerce Inc and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestItemTagAssignment(FrappeTestCase):
+	pass


### PR DESCRIPTION
This pull request introduces a new DocType called `Item Tag Assignment` in the Metactical module, along with its backend logic, client-side scripting, and a basic test case. The main goal is to enable users to assign tags to items based on dynamic filters, with a user-friendly interface for managing conditions and viewing item counts.

Key changes include:

**New DocType Definition and Permissions**

* Added the `Item Tag Assignment` DocType with fields for rule name, tag, filter conditions (as HTML), filters (stored as JSON), and item count display. The DocType is only accessible to System Managers and includes custom naming and view settings.

**Frontend Logic for Dynamic Filtering**

* Implemented `item_tag_assignment.js` to provide a filter UI for selecting items, dynamically update item counts based on filters, and store filter definitions in the hidden `filters` field. The script ensures the UI reflects the current filter state and updates the backend data accordingly.

**Backend Validation Logic**

* Added a Python class for `ItemTagAssignment` that validates the presence of filters before saving, preventing incomplete assignments.

**Testing**

* Added a basic unit test scaffold for the new DocType, ensuring it integrates with the Frappe test framework.