### PR TITLE
Auto assign SB Tags based on website specification labels

### DIFF
--- a/metactical/custom_scripts/item/item.js
+++ b/metactical/custom_scripts/item/item.js
@@ -1,27 +1,6 @@
 frappe.ui.form.on("Item", {
     refresh: function (frm) {
-        frm.trigger("load_website_specifications_options");
-    },
-    load_website_specifications_options: function (frm) {
-        if (frm.doc.neb_website_specifications.length) {
-            var labels = frm.doc.neb_website_specifications.map(
-                (row) => row.label
-            );
-
-            frappe.call({
-                method: "metactical.custom_scripts.item.item.get_website_specification_description_options",
-                args: {
-                    labels: labels,
-                },
-                callback: function (r) {
-                    var descriptions = get_descriptions_dict(frm, r.message);
-                    frm.events.update_web_specification_description_options(
-                        frm,
-                        descriptions
-                    );
-                },
-            })
-        }
+        metactical.utils.load_website_specifications_options(frm);
     },
     neb_copy_from_item_group: function (frm) {
         if (!frm.doc.item_group) {
@@ -70,7 +49,7 @@ frappe.ui.form.on("Item", {
                 
                     // Refresh field + update descriptions
                     frm.refresh_field("neb_website_specifications");
-                    frm.events.update_web_specification_description_options(
+                    metactical.utils.update_web_specification_description_options(
                         frm,
                         descriptions
                     );
@@ -78,39 +57,7 @@ frappe.ui.form.on("Item", {
             },
         });
     },
-    update_web_specification_description_options: function (frm, descriptions_obj) {
-        if (!descriptions_obj) {
-            return;
-        }
-
-        // Update the options of the description field
-        const website_spec_label_rows = cur_frm.fields_dict["neb_website_specifications"].grid.grid_rows;
-        var total_rows = website_spec_label_rows.length;
-        var rows = website_spec_label_rows.map((row) => row.doc);
-        var descriptions = [];
-
-        // get the values for each object and add them to an array
-        $.each(rows, function (index, row) {
-            if (descriptions_obj[row.label]) {
-                descriptions.push(descriptions_obj[row.label]);
-            } else {
-                descriptions.push([]);
-            }
-        });
-
-        for (var row = 0; row < total_rows; row++) {
-            if (rows[row].mandatory == 0) {
-                descriptions[row].unshift("");
-            }
-
-            frappe.utils.filter_dict(
-                website_spec_label_rows[row].docfields,
-                { fieldname: "description" }
-            )[0].options = descriptions[row];
-        }
-
-        frm.refresh_field("neb_website_specifications");
-    },
+    
 });
 
 frappe.ui.form.on("MT Item Website Specification", {
@@ -131,20 +78,11 @@ frappe.ui.form.on("MT Item Website Specification", {
     },
 });
 
+frappe.ui.form.on("Item SB Tag", {
+    sb_tag: function (frm, cdt, cdn) {
+        var row = locals[cdt][cdn];
+        row.manual_selection = 1;
+    },
+});
 
-function get_descriptions_dict(frm, r) {
-    var descriptions = {};
-    r.forEach((row) => {
-        if (!descriptions[row.parent]) {
-            descriptions[row.parent] = [];
-        }
 
-        descriptions[row.parent].push(row.description);
-    });
-
-    // get the values for each object and add them to an array
-    frm.events.update_web_specification_description_options(
-        frm,
-        descriptions
-    );
-}

--- a/metactical/custom_scripts/item/item.py
+++ b/metactical/custom_scripts/item/item.py
@@ -166,7 +166,7 @@ class CustomItem(Item):
                 if row.label and row.description
             }
             
-            if tag_specs and tag_specs.issubset(item_specs):
+            if tag_specs and item_specs.issubset(tag_specs):
                 if tag_doc.name not in manual_tags:
                     self.append("sb_tags", {
                         "sb_tag": tag_doc.name

--- a/metactical/custom_scripts/item/item.py
+++ b/metactical/custom_scripts/item/item.py
@@ -166,7 +166,7 @@ class CustomItem(Item):
                 if row.label and row.description
             }
             
-            if tag_specs and item_specs.issubset(tag_specs):
+            if tag_specs and tag_specs.issubset(item_specs):
                 if tag_doc.name not in manual_tags:
                     self.append("sb_tags", {
                         "sb_tag": tag_doc.name

--- a/metactical/custom_scripts/item/item.py
+++ b/metactical/custom_scripts/item/item.py
@@ -116,8 +116,6 @@ class CustomItem(Item):
         if not frappe.flags.get("item_from_excel"):
             frappe.flags.in_import = False
 
-        load_tags(self)
-
         if not self.description or self.description.strip() == '<div class="ql-editor read-mode"><p><br></p></div>':
             self.description = self.item_name
             
@@ -129,12 +127,52 @@ class CustomItem(Item):
         
         # check website specification values
         validate_website_specifications(self)
-        sync_website_specifications(self)
         validate_item_group(self)
+        self.update_item_inventory_output()
+        self.update_sb_tags()
         
         if self.drop_and_create_in_websites:
             self.create_item_deletion_log()
+            
+    def update_sb_tags(self):
+        if not self.neb_website_specifications:
+            return
 
+        item_specs = {
+            (row.label, row.description)
+            for row in self.neb_website_specifications
+            if row.label and row.description
+        }
+
+        # ------------------------------------------------
+        # Get all SB Tags
+        # ------------------------------------------------
+        sb_tags = frappe.get_all(
+            "SB Tag",
+            fields=["name"]
+        )
+
+        # Clear existing tags with manual_selection = 0
+        self.set("sb_tags", [tag for tag in self.sb_tags if tag.manual_selection])
+        manual_tags = {tag.sb_tag for tag in self.sb_tags if tag.manual_selection}
+
+        for tag in sb_tags:
+            tag_doc = frappe.get_doc("SB Tag", tag.name)
+
+            # Convert tag table into set
+            tag_specs = {
+                (row.label, row.description)
+                for row in tag_doc.neb_website_specifications
+                if row.label and row.description
+            }
+            
+            if tag_specs and tag_specs.issubset(item_specs):
+                if tag_doc.name not in manual_tags:
+                    self.append("sb_tags", {
+                        "sb_tag": tag_doc.name
+                    })
+
+    def update_item_inventory_output(self):
         # Trigger update for item inventory output if deduct_qty has been updated
         # Retrieve the document state before the update
         doc_before_update = self.get_doc_before_save()
@@ -195,36 +233,7 @@ class CustomItem(Item):
             
         frappe.db.set_value(self.doctype, self.name, "drop_and_create_in_websites", 0)
         self.reload()
-    
-def load_tags(doc):
-    """
-    Load tags for the item based on the website specifications.
-    """
-    
-    tags = doc.sb_tags
-    doc.sb_tags = []
-    tags_list = []
-    
-    for tag in tags:
-        if not tag.label and not tag.description:
-            if tag.sb_tag not in tags_list:
-                doc.append("sb_tags", {
-                    "sb_tag": tag.sb_tag,
-                    "label": tag.label,
-                    "description": tag.description,
-                })
-                tags_list.append(tag.sb_tag)
 
-    for spec in doc.neb_website_specifications:
-        if spec.label and spec.description:
-            tag = get_sb_tag(spec.label, spec.description)
-            if tag and tag not in tags_list:
-                doc.append("sb_tags", {
-                    "sb_tag": tag,
-                    "label": spec.label,
-                    "description": spec.description,
-                })
-    
 def validate_website_specifications(doc):
     for spec in doc.neb_website_specifications:
         if not spec.label:
@@ -232,71 +241,6 @@ def validate_website_specifications(doc):
         if spec.mandatory and not spec.description:
             frappe.throw("<b>Description</b> is required for Website Specification at row <b>{0}</b>".format(spec.idx))
     
-def sync_website_specifications(doc):
-    doc_before_update = doc.get_doc_before_save()
-    if not doc_before_update:
-        original_website_specifications = []
-    else:
-        original_website_specifications = doc_before_update.neb_website_specifications
-
-    if not original_website_specifications and not doc.neb_website_specifications:
-        return
-
-    original_website_specifications_dict = {spec.label: {"description": spec.description} for spec in original_website_specifications} if original_website_specifications else {}
-    current_website_specifications = {spec.label: {"description": spec.description} for spec in doc.neb_website_specifications} if doc.neb_website_specifications else {}
-
-    # Check for removed/updated website specifications
-    removed_website_specifications = []
-    for old_label, old_description in original_website_specifications_dict.items():
-        found = False
-        for current_label, current_description in current_website_specifications.items():
-            if old_label == current_label and old_description["description"] == current_description["description"]:
-                found = True
-                break
-
-        if not found:
-            removed_website_specifications.append(old_label)
-
-    # Check for added website specifications
-    added_website_specifications = []
-    for current_label, current_description in current_website_specifications.items():
-        found = False
-        for old_label, old_description in original_website_specifications_dict.items():
-            if old_label == current_label and old_description["description"] == current_description["description"]:
-                found = True
-                break
-
-        if not found:
-            added_website_specifications.append(current_label)
-
-    # recreate the website specifications in the "Website Item" doctype if there is a change in the Item form
-    if added_website_specifications or removed_website_specifications:
-        website_items = frappe.get_all("Website Item", filters={"item_code": doc.item_code}, fields=["name"])
-        if website_items:
-            for item in website_items:
-                website_item = frappe.get_doc("Website Item", item.name)
-                website_item.neb_website_specifications = []
-                website_item.website_specifications = []
-                website_item.save()
-
-                for spec in doc.neb_website_specifications:
-                    website_spec = frappe.new_doc("MT Item Website Specification")
-                    website_spec.label = spec.label
-                    website_spec.description = spec.description
-                    website_spec.mandatory = spec.mandatory
-                    website_spec.parent = website_item.name
-                    website_spec.parenttype = website_item.doctype
-                    website_spec.parentfield = "neb_website_specifications"
-                    website_spec.save()
-
-                    main_website_spec = frappe.new_doc("Item Website Specification")
-                    main_website_spec.label = spec.label
-                    main_website_spec.description = spec.description
-                    main_website_spec.parent = website_item.name
-                    main_website_spec.parenttype = website_item.doctype
-                    main_website_spec.parentfield = "website_specifications"
-                    main_website_spec.save()
-
 def validate_item_group(doc):
     if doc.item_group:
         is_item_group = frappe.db.get_value("Item Group", doc.item_group, "is_group")

--- a/metactical/metactical/doctype/item_sb_tag/item_sb_tag.json
+++ b/metactical/metactical/doctype/item_sb_tag/item_sb_tag.json
@@ -7,8 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "sb_tag",
-  "label",
-  "description"
+  "manual_selection"
  ],
  "fields": [
   {
@@ -20,27 +19,25 @@
    "reqd": 1
   },
   {
-   "fieldname": "label",
-   "fieldtype": "Data",
-   "label": "Label",
-   "read_only": 1
-  },
-  {
-   "fieldname": "description",
-   "fieldtype": "Data",
-   "label": "Description",
+   "default": "0",
+   "fieldname": "manual_selection",
+   "fieldtype": "Check",
+   "label": "Manual Selection",
    "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-17 01:31:05.098321",
+ "modified": "2026-02-03 12:04:36.837763",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Item SB Tag",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/metactical/metactical/doctype/sb_tag/sb_tag.js
+++ b/metactical/metactical/doctype/sb_tag/sb_tag.js
@@ -2,7 +2,13 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('SB Tag', {
-	// refresh: function(frm) {
-
-	// }
+	refresh: function (frm) {
+        metactical.utils.load_website_specifications_options(frm);
+    }, 
 });
+
+frappe.ui.form.on("MT Item Website Specification", {
+	label: function (frm, cdt, cdn) {
+		metactical.utils.load_website_specifications_options(frm);
+	},
+})

--- a/metactical/metactical/doctype/sb_tag/sb_tag.json
+++ b/metactical/metactical/doctype/sb_tag/sb_tag.json
@@ -9,7 +9,7 @@
  "engine": "InnoDB",
  "field_order": [
   "hide_in_filters",
-  "website_specifications",
+  "neb_website_specifications",
   "section_break_sbxf",
   "description"
  ],
@@ -26,20 +26,20 @@
    "label": "Hide In Filters"
   },
   {
-   "fieldname": "website_specifications",
+   "fieldname": "section_break_sbxf",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "neb_website_specifications",
    "fieldtype": "Table",
    "label": "Website Specifications",
    "options": "MT Item Website Specification"
-  },
-  {
-   "fieldname": "section_break_sbxf",
-   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-02 11:23:13.666643",
+ "modified": "2026-02-03 10:05:20.766820",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "SB Tag",

--- a/metactical/metactical/doctype/sb_tag/sb_tag.json
+++ b/metactical/metactical/doctype/sb_tag/sb_tag.json
@@ -9,6 +9,8 @@
  "engine": "InnoDB",
  "field_order": [
   "hide_in_filters",
+  "website_specifications",
+  "section_break_sbxf",
   "description"
  ],
  "fields": [
@@ -22,12 +24,22 @@
    "fieldname": "hide_in_filters",
    "fieldtype": "Check",
    "label": "Hide In Filters"
+  },
+  {
+   "fieldname": "website_specifications",
+   "fieldtype": "Table",
+   "label": "Website Specifications",
+   "options": "MT Item Website Specification"
+  },
+  {
+   "fieldname": "section_break_sbxf",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-29 09:32:22.488412",
+ "modified": "2026-02-02 11:23:13.666643",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "SB Tag",

--- a/metactical/public/js/metactical.bundle.js
+++ b/metactical/public/js/metactical.bundle.js
@@ -1,3 +1,4 @@
 import "./template/shipment_rate.html";
 import "./packing_page_v4.js";
 import "./shipment_rate.js";
+import "./utils.js";

--- a/metactical/public/js/utils.js
+++ b/metactical/public/js/utils.js
@@ -1,0 +1,85 @@
+frappe.provide("metactical.utils");
+
+metactical.utils.format_currency = function(value) {
+    return format_currency(value, frappe.defaults.get_default("currency"));
+};
+
+metactical.utils.show_alert = function(message) {
+    frappe.show_alert({
+        message: message,
+        indicator: "green"
+    });
+};
+
+metactical.utils.load_website_specifications_options = function (frm) {
+    if (frm.doc.neb_website_specifications.length) {
+        var labels = frm.doc.neb_website_specifications.map(
+            (row) => row.label
+        );
+
+        frappe.call({
+            method: "metactical.custom_scripts.item.item.get_website_specification_description_options",
+            args: {
+                labels: labels,
+            },
+            callback: function (r) {
+                var descriptions = metactical.utils.get_descriptions_dict(frm, r.message);
+                metactical.utils.update_web_specification_description_options(
+                    frm,
+                    descriptions
+                );
+            },
+        })
+    }
+}
+
+metactical.utils.update_web_specification_description_options = function (frm, descriptions_obj) {
+    if (!descriptions_obj) {
+        return;
+    }
+
+    // Update the options of the description field
+    const website_spec_label_rows = cur_frm.fields_dict["neb_website_specifications"].grid.grid_rows;
+    var total_rows = website_spec_label_rows.length;
+    var rows = website_spec_label_rows.map((row) => row.doc);
+    var descriptions = [];
+
+    // get the values for each object and add them to an array
+    $.each(rows, function (index, row) {
+        if (descriptions_obj[row.label]) {
+            descriptions.push(descriptions_obj[row.label]);
+        } else {
+            descriptions.push([]);
+        }
+    });
+
+    for (var row = 0; row < total_rows; row++) {
+        if (rows[row].mandatory == 0) {
+            descriptions[row].unshift("");
+        }
+
+        frappe.utils.filter_dict(
+            website_spec_label_rows[row].docfields,
+            { fieldname: "description" }
+        )[0].options = descriptions[row];
+    }
+
+    frm.refresh_field("neb_website_specifications");
+};
+
+metactical.utils.get_descriptions_dict = function(frm, r) {
+    var descriptions = {};
+    r.forEach((row) => {
+        if (!descriptions[row.parent]) {
+            descriptions[row.parent] = [];
+        }
+
+        descriptions[row.parent].push(row.description);
+    });
+
+    // get the values for each object and add them to an array
+    metactical.utils.update_web_specification_description_options(
+        frm,
+        descriptions
+    );
+}


### PR DESCRIPTION
This pull request introduces significant refactoring and feature enhancements around the management of SB Tags and website specifications for items. The main changes include moving utility functions to a shared JavaScript utility module, updating the SB Tag assignment logic to be more robust and automatic, and simplifying the data model for SB Tags. The changes also improve the UI experience for managing website specifications and SB Tags, and remove some outdated or redundant code.

**Refactoring and Utility Consolidation:**
- Moved website specification-related utility functions (`load_website_specifications_options`, `update_web_specification_description_options`, and `get_descriptions_dict`) from individual scripts into a new shared utility module `metactical/public/js/utils.js`, and updated all usages to reference the new location. [[1]](diffhunk://#diff-f874b5c04ac3545fc674f041789e00fc486776baca619c8de560757292d4776dL3-R3) [[2]](diffhunk://#diff-f874b5c04ac3545fc674f041789e00fc486776baca619c8de560757292d4776dL73-L113) [[3]](diffhunk://#diff-f874b5c04ac3545fc674f041789e00fc486776baca619c8de560757292d4776dL134-R88) [[4]](diffhunk://#diff-dd78b935116241b0347e71b5d8131354fcc29f3a47538a0b4a2700f9717d0657R1-R85)

**SB Tag Assignment and Data Model Updates:**
- Overhauled the SB Tag assignment logic: removed the old `load_tags` function and replaced it with a new `update_sb_tags` method on the Item Python class, which now automatically assigns SB Tags based on matching website specifications, and respects manual selections. [[1]](diffhunk://#diff-74c6ff9a43c3a79ceb884446cfc98b0041760bc7c2930381abfbc634050b2583L119-L120) [[2]](diffhunk://#diff-74c6ff9a43c3a79ceb884446cfc98b0041760bc7c2930381abfbc634050b2583L132-R175) [[3]](diffhunk://#diff-74c6ff9a43c3a79ceb884446cfc98b0041760bc7c2930381abfbc634050b2583L199-L299)
- Simplified the `Item SB Tag` child table by removing the `label` and `description` fields and adding a `manual_selection` checkbox to indicate user-selected tags, updating both the JSON schema and related UI logic. [[1]](diffhunk://#diff-759bf7b93c0d8d4c47d2e2af9c8a9574951023d316aeaff67c18505da9634c5aL10-R10) [[2]](diffhunk://#diff-759bf7b93c0d8d4c47d2e2af9c8a9574951023d316aeaff67c18505da9634c5aL23-R40)

**Website Specification Management Enhancements:**
- Added the `neb_website_specifications` table to the `SB Tag` doctype, allowing each tag to define its own set of website specifications for matching. [[1]](diffhunk://#diff-505812dc1d00abbc143595b42ce4d91d9d909d88b164f2c98277050360f1a8d3R12-R13) [[2]](diffhunk://#diff-505812dc1d00abbc143595b42ce4d91d9d909d88b164f2c98277050360f1a8d3R27-R42)
- Improved the UI for both `Item` and `SB Tag` doctypes to refresh website specification options dynamically when relevant fields change.

These changes collectively improve the maintainability of the codebase, enhance the automation and flexibility of SB Tag assignment, and streamline the user experience for managing item specifications and tags.