### PR TITLE
fix: update delivery note creation logic to handle discounts and item quantities from sales orders

### DIFF
--- a/metactical/custom_scripts/pick_list/pick_list.py
+++ b/metactical/custom_scripts/pick_list/pick_list.py
@@ -188,22 +188,44 @@ class CustomPickList(PickList):
 		# 	delivery_note.source = pick_list.ais_source
 		# delivery_note.save()
 
-		delivery_note = create_dn_for_pick_lists(self.name)
 		sales_orders = [d.sales_order for d in self.locations if d.sales_order]
-		sales_orders = set(sales_orders)
-		for sales_order in sales_orders:
-			delivery_note.update({
-				'ignore_pricing_rule': frappe.db.get_value('Sales Order', sales_order, 'ignore_pricing_rule'),
-				"disable_rounded_total": 1
-			})
-			#Add pick list submitted date in sales order
-			sales_doc = frappe.get_doc("Sales Order", sales_order)
-			sales_doc.update({"pick_list_submitted_date": datetime.datetime.now(timezone('US/Pacific')).strftime("%Y-%m-%d %H:%M:%S")})
-			sales_doc.save()
-		delivery_note.save()
-		
-
+		so = sales_orders[0] if sales_orders else None
 	
+		if so:
+			delivery_note = create_delivery_note_from_sales_order(so)
+			items = delivery_note.items
+			dn_items = []
+			total_discount_amount = 0
+   
+			for item in items:
+				for location in self.locations:
+					if location.sales_order_item == item.so_detail:
+						distributed_discount_amount = frappe.db.get_value('Sales Order Item', item.so_detail, 'distributed_discount_amount') or 0
+						total_ordered = frappe.db.get_value('Sales Order Item', item.so_detail, 'qty') or 0
+						if total_ordered:
+							discount_amount = flt(distributed_discount_amount) / flt(total_ordered)
+							total_discount_amount += discount_amount * flt(location.picked_qty)
+						item.qty = location.picked_qty
+      
+						dn_items.append(item)
+						break
+  
+			for sales_order in sales_orders:
+				delivery_note.update({
+					'ignore_pricing_rule': frappe.db.get_value('Sales Order', sales_order, 'ignore_pricing_rule'),
+					"disable_rounded_total": 1
+				})
+    
+				#Add pick list submitted date in sales order
+				sales_doc = frappe.get_doc("Sales Order", sales_order)
+				sales_doc.update({"pick_list_submitted_date": datetime.datetime.now(timezone('US/Pacific')).strftime("%Y-%m-%d %H:%M:%S")})
+				sales_doc.save()
+  
+			delivery_note.items = dn_items
+			delivery_note.discount_amount = total_discount_amount
+			delivery_note.save()
+			frappe.db.commit()
+		
 	
 	def on_cancel(self):
 		super(CustomPickList, self).on_cancel()

--- a/metactical/custom_scripts/pick_list/pick_list.py
+++ b/metactical/custom_scripts/pick_list/pick_list.py
@@ -206,6 +206,8 @@ class CustomPickList(PickList):
 							discount_amount = flt(distributed_discount_amount) / flt(total_ordered)
 							total_discount_amount += discount_amount * flt(location.picked_qty)
 						item.qty = location.picked_qty
+						item.pick_list_item = location.name
+						item.against_pick_list = self.name
       
 						dn_items.append(item)
 						break

--- a/metactical/custom_scripts/pick_list/pick_list.py
+++ b/metactical/custom_scripts/pick_list/pick_list.py
@@ -206,6 +206,7 @@ class CustomPickList(PickList):
 							discount_amount = flt(distributed_discount_amount) / flt(total_ordered)
 							total_discount_amount += discount_amount * flt(location.picked_qty)
 						item.qty = location.picked_qty
+						item.warehouse = location.warehouse
 						item.pick_list_item = location.name
 						item.against_pick_list = self.name
       
@@ -225,6 +226,7 @@ class CustomPickList(PickList):
   
 			delivery_note.items = dn_items
 			delivery_note.discount_amount = total_discount_amount
+			
 			delivery_note.save()
 			frappe.db.commit()
 		


### PR DESCRIPTION
This pull request refactors the `on_submit` method in `pick_list.py` to improve how delivery notes are created from pick lists. The changes ensure that delivery notes are generated based on the associated sales order, with accurate item quantities, warehouse assignments, and discount calculations. The code now updates the sales order with the pick list submission date and commits the transaction after saving the delivery note.

**Delivery Note Creation and Item Handling:**

* Replaced the previous delivery note creation logic with a process that creates a delivery note from the first associated sales order, ensuring that only relevant items are included and their quantities, warehouses, and pick list references are set based on the pick list's locations.
* Calculated and assigned the total discount amount for the delivery note by distributing discounts proportionally based on picked quantities for each item.

**Sales Order Updates:**

* Updated the sales order's `pick_list_submitted_date` field with the current date and time in the US/Pacific timezone upon pick list submission.

**Transaction Handling:**

* Added an explicit call to `frappe.db.commit()` after saving the delivery note to ensure all changes are committed to the database.