### PR TITLE
feat: upload purchase receipts to rocket chat

### DIFF
--- a/metactical/custom_scripts/purchase_receipt/purchase_receipt.py
+++ b/metactical/custom_scripts/purchase_receipt/purchase_receipt.py
@@ -2,7 +2,7 @@ import frappe
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import PurchaseReceipt
 from frappe.utils import flt, cstr, now, get_datetime_str, file_lock, date_diff, now_datetime, cint
 from frappe import _, msgprint, is_whitelisted
-from metactical.custom_scripts.utils.metactical_utils import queue_action
+from metactical.custom_scripts.utils.metactical_utils import queue_action, post_to_rocket_chat
 from frappe.model.docstatus import DocStatus
 
 class CustomPurchaseReceipt(PurchaseReceipt):
@@ -44,6 +44,13 @@ class CustomPurchaseReceipt(PurchaseReceipt):
 			if not barcode_exists:
 				frappe.throw(f"Error: Please add a barcode for item {item.item_code}")
 
+	def on_submit(self):
+		super(CustomPurchaseReceipt, self).on_submit()
+		frappe.enqueue(
+			send_pdf_to_rocket_chat,
+			name=self.name
+		)
+
 def validate(self, method):
 	if self.set_warehouse:
 		for item in self.items:
@@ -72,3 +79,36 @@ def get_pr_items(docname):
 def get_print_format(docname):
 	doc = frappe.get_doc('Purchase Receipt', docname)
 	return frappe.get_print(doctype=doc.doctype, name=doc.name, print_format="Purchase Receipt Barcode - V2", no_letterhead=0)
+
+
+@frappe.whitelist()
+def send_pdf_to_rocket_chat(name):
+    try:
+        doc = frappe.get_doc("Purchase Receipt", name)
+
+        html = frappe.get_print(
+            "Purchase Receipt",
+            name,
+            print_format="PR Report V5",
+            no_letterhead=0,
+        )
+        pdf_content = frappe.utils.pdf.get_pdf(html)
+
+        supplier = frappe.get_doc("Supplier", doc.supplier)
+        po = doc.purchase_order
+        if supplier.country == "China":
+            filename = f"China PO-{po}.pdf"
+        else:
+            filename = f"{supplier.name} PO-{po}.pdf"
+
+        post_to_rocket_chat(
+            doc=doc,
+            msg=None,
+            attachment=pdf_content,
+            filename=filename,
+        )
+    except Exception:
+        frappe.log_error(
+            title="Rocket Chat PDF Upload Failed",
+            message=frappe.get_traceback(),
+        )

--- a/metactical/custom_scripts/utils/metactical_utils.py
+++ b/metactical/custom_scripts/utils/metactical_utils.py
@@ -44,13 +44,17 @@ def queue_action(self, action, **kwargs):
 def post_to_rocket_chat(doc, msg, failed=False, rmq=False, pos=False, attachment=None, filename=None):
 	try:
 		rocket_chat_settings = frappe.get_single('Rocket Chat Settings')
-		if not rocket_chat_settings.rocket_notification:
+
+		if attachment and filename:
 			if not rocket_chat_settings.pr_rocket_notification:
 				return
 			else:
 				if not rocket_chat_settings.pr_room_id:
 					frappe.log_error(title='Rocket Chat Error', message="PR Room ID not found in settings")
 					return
+ 
+		elif not rocket_chat_settings.rocket_notification:
+				return
 
 		if attachment and filename:
 			headers = {

--- a/metactical/custom_scripts/utils/metactical_utils.py
+++ b/metactical/custom_scripts/utils/metactical_utils.py
@@ -44,17 +44,13 @@ def queue_action(self, action, **kwargs):
 def post_to_rocket_chat(doc, msg, failed=False, rmq=False, pos=False, attachment=None, filename=None):
 	try:
 		rocket_chat_settings = frappe.get_single('Rocket Chat Settings')
-
-		if attachment and filename:
+		if not rocket_chat_settings.rocket_notification:
 			if not rocket_chat_settings.pr_rocket_notification:
 				return
 			else:
 				if not rocket_chat_settings.pr_room_id:
 					frappe.log_error(title='Rocket Chat Error', message="PR Room ID not found in settings")
 					return
- 
-		elif not rocket_chat_settings.rocket_notification:
-				return
 
 		if attachment and filename:
 			headers = {

--- a/metactical/metactical/doctype/rocket_chat_settings/rocket_chat_settings.json
+++ b/metactical/metactical/doctype/rocket_chat_settings/rocket_chat_settings.json
@@ -7,11 +7,13 @@
  "engine": "InnoDB",
  "field_order": [
   "rocket_notification",
+  "pr_rocket_notification",
   "url",
   "content_type",
   "auth_token",
   "user_id",
   "channel_name",
+  "pr_room_id",
   "pos_failed_invoices"
  ],
  "fields": [
@@ -58,12 +60,26 @@
    "fieldname": "pos_failed_invoices",
    "fieldtype": "Data",
    "label": "POS Failed Invoices Channel"
+  },
+  {
+   "default": "0",
+   "fieldname": "pr_rocket_notification",
+   "fieldtype": "Check",
+   "label": "Post PR Submission Notification To Rocket Chat"
+  },
+  {
+   "fieldname": "pr_room_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "PR Room Id",
+   "reqd": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-11 04:17:26.359979",
+ "modified": "2026-03-31 11:18:05.625520",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Rocket Chat Settings",
@@ -80,6 +96,8 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
This pull request introduces a new feature that automatically sends a PDF of the Purchase Receipt to Rocket Chat upon submission, along with supporting changes to the Rocket Chat settings to enable and configure this notification. The main updates include backend logic for PDF generation and sending, as well as new configuration fields for Rocket Chat integration.

**Purchase Receipt to Rocket Chat Integration:**

* Added a new method `send_pdf_to_rocket_chat` that generates a PDF of the Purchase Receipt and posts it to Rocket Chat, with error handling and dynamic filename generation based on supplier country.
* Modified the `CustomPurchaseReceipt` class to enqueue the `send_pdf_to_rocket_chat` function automatically on submission of a Purchase Receipt.
* Imported the `post_to_rocket_chat` utility function to support sending messages and attachments to Rocket Chat.

**Rocket Chat Settings Enhancements:**

* Added new fields to `rocket_chat_settings.json` for enabling PR submission notifications (`pr_rocket_notification`) and specifying the target Rocket Chat room (`pr_room_id`). [[1]](diffhunk://#diff-b79c45b62df3786ef3144c3643ae759885456db197d9088b35eed74f51cab554R10-R16) [[2]](diffhunk://#diff-b79c45b62df3786ef3144c3643ae759885456db197d9088b35eed74f51cab554R63-R82)
* Updated metadata in `rocket_chat_settings.json` to support the new fields and improve grid behavior (e.g., row formatting, grid search threshold).