### PR TITLE
chore: Improve usaepay sucessful payment message, conversion rate update for ret - camofrn - usd

### DIFF
--- a/metactical/custom_scripts/payment_entry/payment_entry.js
+++ b/metactical/custom_scripts/payment_entry/payment_entry.js
@@ -531,7 +531,10 @@ var make_payment = function (frm, values, tokens) {
             if (res.error) {
                 frappe.msgprint(res.error);
             } else {
-                frappe.msgprint("Payment successful");
+                frappe.msgprint(
+                    `✅ Payment successful: <b>${res.amount}</b> has been processed successfully ` +
+                    `${res.card_holder ? " using the card registered to <b>" + res.card_holder : ""}.`
+                );
                 frm.reload_doc();
             }
         },

--- a/metactical/custom_scripts/sales_order/sales_order.js
+++ b/metactical/custom_scripts/sales_order/sales_order.js
@@ -63,7 +63,29 @@ frappe.ui.form.on('Sales Order', {
 		
 		cur_frm.fields_dict["section_break_48"].collapse(0);
 	},
+	plc_conversion_rate: function(frm) {
+        if (frm.doc.selling_price_list !== "RET - CamoFRN - USD") return;
+        if (!frm.doc.plc_conversion_rate) return;
 
+        let current = flt(frm.doc.plc_conversion_rate);
+
+        // store backend value once (true base)
+        if (!frm._base_plc_rate) {
+            frm._base_plc_rate = current;
+        }
+
+        let expected = frm._base_plc_rate + 0.02;
+
+        // ONLY adjust if not already adjusted
+        if (Math.abs(current - expected) > 0.0001) {
+            frm.set_value("plc_conversion_rate", expected);
+        }
+    },
+
+    selling_price_list: function(frm) {
+        // reset base when price list changes
+        frm._base_plc_rate = null;
+    },
 	onload: function(frm){
 		old_tax_template = frm.doc.taxes_and_charges;
 		base_in_words = frm.doc.base_in_words;

--- a/metactical/custom_scripts/usaepay/usaepay_api.py
+++ b/metactical/custom_scripts/usaepay/usaepay_api.py
@@ -579,6 +579,7 @@ def make_payment(customer, amount, token, payment_entry=None):
 	if not customer:
 		frappe.throw(_("Customer is required"))
 
+	customer_cc = None
 	if token:
 		customer_cc = frappe.db.get_value("Customer CC Tokens", token, ["token", "card_holder"], as_dict=1)
 		if not customer_cc:

--- a/metactical/custom_scripts/usaepay/usaepay_api.py
+++ b/metactical/custom_scripts/usaepay/usaepay_api.py
@@ -659,6 +659,9 @@ def handle_payment_response(response, log):
 
 		log.transaction_key = transaction.get("key")
 		frappe.response["success"] = True
+		frappe.response["transaction_key"] = transaction.get("key")
+		frappe.response["amount"] = transaction.get("auth_amount")
+		frappe.response["card_holder"] = transaction.get("creditcard", {}).get("cardholder")
 	else:
 		response = json.loads(response.text)
 		log.response = format_json_for_html(response)


### PR DESCRIPTION
This pull request introduces improvements to the payment processing flow and enhances user feedback in the UI. The main changes include more informative payment success messages, adjustments to the handling of conversion rates in Sales Orders, and enhancements to the payment API responses.

### Payment flow and user feedback improvements

* The payment success message in `payment_entry.js` now displays the processed amount and, if available, the cardholder's name, providing clearer feedback to users.
* The backend payment API (`usaepay_api.py`) now includes `amount` and `card_holder` in the response, allowing the frontend to display these details after a successful payment.

### Sales Order conversion rate logic

* Added logic in `sales_order.js` to automatically adjust the `plc_conversion_rate` for the "RET - CamoFRN - USD" price list, ensuring it is always set to the backend base value plus 0.02, and to reset the base rate when the price list changes.

### Codebase improvements

* Initialized `customer_cc` to `None` in the `make_payment` function for improved code clarity and safety.