### PR TITLE
chore: don't post return purchase receipts to rocket chat, new field 'is product selector' in the website specification label

### DIFF
--- a/metactical/custom_scripts/purchase_receipt/purchase_receipt.py
+++ b/metactical/custom_scripts/purchase_receipt/purchase_receipt.py
@@ -46,10 +46,11 @@ class CustomPurchaseReceipt(PurchaseReceipt):
 
 	def on_submit(self):
 		super(CustomPurchaseReceipt, self).on_submit()
-		frappe.enqueue(
-			send_pdf_to_rocket_chat,
-			name=self.name
-		)
+		if not self.is_return:
+			frappe.enqueue(
+				send_pdf_to_rocket_chat,
+				name=self.name
+			)
 
 def validate(self, method):
 	if self.set_warehouse:

--- a/metactical/metactical/doctype/website_specification_label/website_specification_label.json
+++ b/metactical/metactical/doctype/website_specification_label/website_specification_label.json
@@ -51,13 +51,15 @@
    "default": "0",
    "fieldname": "is_a_product_selector",
    "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Is A Product Selector"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-06 09:01:01.646890",
+ "modified": "2026-04-06 09:07:31.092567",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Website Specification Label",

--- a/metactical/metactical/doctype/website_specification_label/website_specification_label.json
+++ b/metactical/metactical/doctype/website_specification_label/website_specification_label.json
@@ -11,6 +11,7 @@
   "label",
   "sort_order",
   "is_a_search_filter",
+  "is_a_product_selector",
   "section_break_0mlim",
   "descriptions"
  ],
@@ -30,22 +31,33 @@
   {
    "fieldname": "sort_order",
    "fieldtype": "Int",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Sort Order"
   },
   {
    "default": "0",
    "fieldname": "is_a_search_filter",
    "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Is A Search Filter"
   },
   {
    "fieldname": "section_break_0mlim",
    "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_a_product_selector",
+   "fieldtype": "Check",
+   "label": "Is A Product Selector"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-25 07:33:20.678214",
+ "modified": "2026-04-06 09:01:01.646890",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Website Specification Label",
@@ -65,6 +77,8 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
This pull request introduces enhancements to the `Website Specification Label` DocType and a minor logic update to the purchase receipt submission process. The main focus is on improving the usability and filtering capabilities of the label management interface, as well as ensuring that Rocket.Chat notifications are only sent for non-return purchase receipts.

**Enhancements to Website Specification Label DocType:**

* Added a new field `is_a_product_selector`, including it in both list and filter views, to allow easier identification and selection of product selector labels. [[1]](diffhunk://#diff-13c960a9af5d049dfcd3f4b24fbe244e246b9d28568d7e43421240488782626bR14) [[2]](diffhunk://#diff-13c960a9af5d049dfcd3f4b24fbe244e246b9d28568d7e43421240488782626bR34-R62)
* Enabled `sort_order` and `is_a_search_filter` fields to appear in list and standard filter views for improved filtering and sorting.
* Increased the default grid page length to 50 and set the row format to `Dynamic` for better data management in the UI. [[1]](diffhunk://#diff-13c960a9af5d049dfcd3f4b24fbe244e246b9d28568d7e43421240488782626bR34-R62) [[2]](diffhunk://#diff-13c960a9af5d049dfcd3f4b24fbe244e246b9d28568d7e43421240488782626bR82-R83)
* Introduced a threshold for grid search (`rows_threshold_for_grid_search`: 20) to optimize performance with larger datasets.

**Logic update in Purchase Receipt:**

* Modified the `on_submit` method in `CustomPurchaseReceipt` so that the PDF is sent to Rocket.Chat only if the receipt is not a return, preventing unnecessary notifications.