### PR TITLE
fix: show taxes and fees table for draft purchase orders

### DIFF
--- a/metactical/custom_scripts/purchase_order/purchase_order.js
+++ b/metactical/custom_scripts/purchase_order/purchase_order.js
@@ -1,17 +1,21 @@
 frappe.ui.form.on('Purchase Order', {
 	refresh: function(frm){
-		var allow_tax_edit = 1;
-		if(frm.doc.__onload && frm.doc.__onload['ais_allow_tax_edit']){
-			allow_tax_edit = 0;
-		}
-		frm.set_df_property('taxes', 'read_only', allow_tax_edit);
-		frm.doc.taxes.forEach((row)=>{
-			var tax_fields = ['charge_type', 'account_head', 'rate']
-			tax_fields.forEach((field) => {
-				frappe.meta.get_docfield(row.doctype, field, row.name).read_only = allow_tax_edit;
+		if (frm.doc.docstatus == 1) {
+			var allow_tax_edit = 1;
+
+			if(frm.doc.__onload && frm.doc.__onload['ais_allow_tax_edit']){
+				allow_tax_edit = 0;
+			}
+
+			frm.set_df_property('taxes', 'read_only', allow_tax_edit);
+			frm.doc.taxes.forEach((row)=>{
+				var tax_fields = ['charge_type', 'account_head', 'rate']
+				tax_fields.forEach((field) => {
+					frappe.meta.get_docfield(row.doctype, field, row.name).read_only = allow_tax_edit;
+				});
+				frm.refresh_field("taxes");
 			});
-			frm.refresh_field("taxes");
-		});
+		}
 	}
 });
 

--- a/metactical/fixtures/property_setter.json
+++ b/metactical/fixtures/property_setter.json
@@ -8967,7 +8967,7 @@
   "doctype_or_field": "DocField",
   "field_name": "disabled",
   "is_system_generated": 0,
-  "modified": "2026-03-09 06:37:26.693919",
+  "modified": "2026-04-09 06:37:26.693919",
   "module": null,
   "name": "Item-disabled-permlevel",
   "property": "permlevel",


### PR DESCRIPTION
This pull request introduces a minor update to the `Purchase Order` custom script to ensure the taxes table is set to read-only only when the document is submitted, and also updates a timestamp in the property setter fixture. The main functional change is a refinement in the UI logic for editing taxes.

Functional change to Purchase Order form:

* The taxes table (`taxes` field) is now set to read-only only when the `Purchase Order` document is submitted (`docstatus == 1`), improving the accuracy of when users can edit tax information. [[1]](diffhunk://#diff-0c1e314ddf503013d1d8c46954577eb09afc9af75337a1b8e7f3b8c769d7bae8R3-R9) [[2]](diffhunk://#diff-0c1e314ddf503013d1d8c46954577eb09afc9af75337a1b8e7f3b8c769d7bae8R19)

Other change:

* Updated the `modified` timestamp in the `Item-disabled-permlevel` property setter fixture; no functional impact.