### PR TITLE
fix: remove enquiing for item title update

### DIFF
--- a/metactical/utils/rename_doc.py
+++ b/metactical/utils/rename_doc.py
@@ -50,6 +50,9 @@ def update_document_title(
 	# handle bad API usages
 	merge = sbool(merge)
 	enqueue = sbool(enqueue)
+ 
+	if doctype == "Item":
+		enqueue = False
 
 	doc = frappe.get_doc(doctype, docname)
 	doc.check_permission(permtype="write")
@@ -61,8 +64,6 @@ def update_document_title(
 
 	queue = kwargs.get("queue") or "long"
  
-	print("renaming called from the utility customization")
-
 	if name_updated:
 		if enqueue and not is_scheduler_inactive():
 			current_name = doc.name
@@ -90,7 +91,6 @@ def update_document_title(
 
 	if title_updated:
 		try:
-			doc.reload()
 			setattr(doc, title_field, updated_title)
 			doc.save()
 			frappe.msgprint(_("Saved"), alert=True, indicator="green")


### PR DESCRIPTION
This pull request makes targeted adjustments to the `update_document_title` function in `metactical/utils/rename_doc.py` to improve its behavior, especially for the `Item` doctype, and to clean up the code for clarity. The most important changes are:

Behavioral changes for specific doctypes:
* For the `Item` doctype, the `enqueue` flag is now forcibly set to `False`, ensuring that renaming for this type is not queued.

Code cleanup and simplification:
* Removed an unnecessary debug print statement that was used during utility customization.

Stability and performance:
* Eliminated the redundant `doc.reload()` call before updating the document's title, as it is not required for the update and save operations.