### PR TITLE
feature: Kits doctype, include printable comments in POS API response

### DIFF
--- a/metactical/api/sales_invoice.py
+++ b/metactical/api/sales_invoice.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe import _
 from metactical.custom_scripts.utils.metactical_utils import get_returns, group_invoice_data
+from bs4 import BeautifulSoup
 
 @frappe.whitelist()
 def load_si_from_so_pos(sales_order):
@@ -23,7 +24,7 @@ def load_si_from_so_pos(sales_order):
     
     sales_invoice = get_sales_invoice(sales_order.name)
     if sales_invoice:
-        sales_invoice = load_si_pos(sales_invoice.parent)
+        sales_invoice = load_si_pos(sales_invoice.parent, sales_order)
     else:
         frappe.response["Status"] = 404
         frappe.response["Message"] = f"{sales_order.name} has no Paid or Credit Note Issued Sales Invoice"
@@ -45,7 +46,7 @@ def get_sales_invoice(sales_order):
     return invoice
 
 @frappe.whitelist()
-def load_si_pos(sales_invoice):
+def load_si_pos(sales_invoice, sales_order):
     message = ""
     status = 200
     invoice = None
@@ -123,7 +124,7 @@ def load_si_pos(sales_invoice):
 
     invoice_details["ApprovalList"] = []
     invoice_details["SalesPerson"] = invoice.owner
-    invoice_details["Comments"] = []
+    invoice_details["Comments"] = get_comments(sales_order)
     invoice_details["InvoiceId"] = invoice.name
     invoice_details["Total"] = invoice.grand_total
     invoice_details["PriceList"] = invoice.selling_price_list
@@ -165,7 +166,7 @@ def load_so_pos(sales_order):
     
     order_details["ApprovalList"] = []
     order_details["SalesPerson"] = sales_order.owner
-    order_details["Comments"] = []
+    order_details["Comments"] = get_comments(sales_order)
     order_details["InvoiceId"] = sales_order.name
     order_details["Total"] = sales_order.grand_total
     order_details["PriceList"] = sales_order.selling_price_list
@@ -278,3 +279,16 @@ def get_address_detail(sales_order):
     customer["Country"] = customer_contact.get("country")
     
     return customer
+
+def get_comments(doc):
+    # get all commments for the doc that start with "printable:"
+    comments = frappe.db.get_all("Comment", filters={"reference_doctype": doc.doctype, "reference_name": doc.name, "comment_type": "Comment"}, fields=["content", "comment_by"])
+    printable_comments = []
+    for comment in comments:
+        soup = BeautifulSoup(comment.content, "html.parser")
+        text = soup.get_text()
+        
+        if text and text.lower().startswith("printable:"):
+            printable_comments.append({"UserId": comment.comment_by, "Text": text})
+            
+    return printable_comments

--- a/metactical/metactical/doctype/kits/kits.js
+++ b/metactical/metactical/doctype/kits/kits.js
@@ -10,6 +10,14 @@ frappe.ui.form.on("Kits", {
                 }
             }
         });
+
+        frm.set_query("kit_item", function(){
+            return {
+                filters: {
+                    is_stock_item: 0
+                }
+            }
+        });
 	},
 });
 

--- a/metactical/metactical/doctype/kits/kits.js
+++ b/metactical/metactical/doctype/kits/kits.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, Storebuilder Commerce Inc and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Kits", {
+	refresh(frm) {
+        frm.set_query("item_code", "kit_items", function() {
+            return {
+                filters: {
+                    has_variants: 1
+                }
+            }
+        });
+	},
+});
+
+frappe.ui.form.on("Product Bundle Item", {
+    item_code: function(frm, cdt, cdn){
+        let row = locals[cdt][cdn];
+        row.qty = 1;
+        frm.refresh_field("kit_items");
+    }
+});

--- a/metactical/metactical/doctype/kits/kits.json
+++ b/metactical/metactical/doctype/kits/kits.json
@@ -1,12 +1,13 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:kit_name",
+ "autoname": "field:kit_item",
  "creation": "2026-04-01 12:04:36.929615",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "kit_name",
+  "section_break_vpnf",
+  "kit_item",
   "discount_percentage",
   "column_break_jise",
   "disabled",
@@ -16,14 +17,6 @@
   "kit_items"
  ],
  "fields": [
-  {
-   "fieldname": "kit_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Kit Name",
-   "reqd": 1,
-   "unique": 1
-  },
   {
    "fieldname": "discount_percentage",
    "fieldtype": "Float",
@@ -60,12 +53,23 @@
    "label": "Kit Items",
    "options": "Product Bundle Item",
    "reqd": 1
+  },
+  {
+   "fieldname": "kit_item",
+   "fieldtype": "Link",
+   "label": "Kit Item",
+   "options": "Item",
+   "unique": 1
+  },
+  {
+   "fieldname": "section_break_vpnf",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-01 12:13:07.266452",
+ "modified": "2026-04-02 10:28:55.368091",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Kits",

--- a/metactical/metactical/doctype/kits/kits.json
+++ b/metactical/metactical/doctype/kits/kits.json
@@ -1,0 +1,93 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:kit_name",
+ "creation": "2026-04-01 12:04:36.929615",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "kit_name",
+  "discount_percentage",
+  "column_break_jise",
+  "disabled",
+  "section_break_mayz",
+  "websites",
+  "section_break_cxpf",
+  "kit_items"
+ ],
+ "fields": [
+  {
+   "fieldname": "kit_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Kit Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "discount_percentage",
+   "fieldtype": "Float",
+   "label": "Discount Percentage"
+  },
+  {
+   "fieldname": "column_break_jise",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
+  },
+  {
+   "fieldname": "section_break_mayz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "websites",
+   "fieldtype": "Table",
+   "label": "Websites",
+   "options": "Lead Sources",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_cxpf",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "kit_items",
+   "fieldtype": "Table",
+   "label": "Kit Items",
+   "options": "Product Bundle Item",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-04-01 12:13:07.266452",
+ "modified_by": "Administrator",
+ "module": "Metactical",
+ "name": "Kits",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/metactical/metactical/doctype/kits/kits.py
+++ b/metactical/metactical/doctype/kits/kits.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Storebuilder Commerce Inc and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Kits(Document):
+	pass

--- a/metactical/metactical/doctype/kits/test_kits.py
+++ b/metactical/metactical/doctype/kits/test_kits.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Storebuilder Commerce Inc and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestKits(FrappeTestCase):
+	pass


### PR DESCRIPTION
This pull request introduces a new "Kits" DocType to the application, including its backend, frontend, and test scaffolding. Additionally, it enhances the sales invoice API by improving how comments are retrieved and displayed for sales orders and invoices.

**New "Kits" DocType Implementation:**

* Added a new DocType `Kits` with fields for kit items, discount percentage, and related websites, along with permissions and configuration (`kits.json`).
* Implemented the backend class for `Kits` as a subclass of `Document` (`kits.py`).
* Added a test scaffold for the `Kits` DocType (`test_kits.py`).

**Frontend Enhancements for Kits:**

* Introduced client-side logic for the `Kits` form: set filters for item selection and default quantity behavior for kit items (`kits.js`).

**Sales Invoice API Improvements:**

* Enhanced the `load_si_from_so_pos` and related functions to retrieve and include "printable:" comments from sales orders and invoices, using a new `get_comments` helper that parses and filters comments with BeautifulSoup (`sales_invoice.py`). [[1]](diffhunk://#diff-d8f3a2084d3887567e56cf2f83ccebe4aa6bb9b9ec4ff7160f05ce487fa99255R4) [[2]](diffhunk://#diff-d8f3a2084d3887567e56cf2f83ccebe4aa6bb9b9ec4ff7160f05ce487fa99255L26-R27) [[3]](diffhunk://#diff-d8f3a2084d3887567e56cf2f83ccebe4aa6bb9b9ec4ff7160f05ce487fa99255L48-R49) [[4]](diffhunk://#diff-d8f3a2084d3887567e56cf2f83ccebe4aa6bb9b9ec4ff7160f05ce487fa99255L126-R127) [[5]](diffhunk://#diff-d8f3a2084d3887567e56cf2f83ccebe4aa6bb9b9ec4ff7160f05ce487fa99255L168-R169) [[6]](diffhunk://#diff-d8f3a2084d3887567e56cf2f83ccebe4aa6bb9b9ec4ff7160f05ce487fa99255R282-R294)