### PR TITLE
feature: add item group validation to assign SB Tags

### DIFF
--- a/metactical/custom_scripts/item/item.py
+++ b/metactical/custom_scripts/item/item.py
@@ -324,59 +324,42 @@ class CustomItem(Item):
             self.create_item_deletion_log()
             
     def update_sb_tags(self):
-        matched_tags = set()
-
-        if self.item_group:
-            matched_tags.update(
-                frappe.get_all(
-                    "Item Groups List",
-                    filters={
-                        "parenttype": "SB Tag",
-                        "parentfield": "nat_item_groups",
-                        "item_group": self.item_group,
-                    },
-                    pluck="parent",
-                )
-            )
-
-        for row in self.neb_website_specifications or []:
-            if not row.label or not row.description:
-                continue
-
-            matched_tags.update(
-                frappe.get_all(
-                    "MT Item Website Specification",
-                    filters={
-                        "parenttype": "SB Tag",
-                        "parentfield": "neb_website_specifications",
-                        "label": row.label,
-                        "description": row.description,
-                    },
-                    pluck="parent",
-                )
-            )
-
-            matched_tags.update(
-                tag
-                for tag in frappe.get_all(
-                    "Website Spec Label Descriptions",
-                    filters={
-                        "parent": row.label,
-                        "description": row.description,
-                    },
-                    pluck="sb_tag",
-                )
-                if tag
-            )
+        item_specs = {
+            (row.label, row.description)
+            for row in self.neb_website_specifications or []
+            if row.label and row.description
+        }
 
         manual_rows = [tag for tag in self.sb_tags if tag.manual_selection]
         manual_tags = {tag.sb_tag for tag in manual_rows if tag.sb_tag}
 
         self.set("sb_tags", manual_rows)
+        
+        sb_tags = frappe.get_all("SB Tag", pluck="name")
+        for tag_name in sb_tags:
+            tag_doc = frappe.get_doc("SB Tag", tag_name)
+            tag_specs = {
+                (row.label, row.description)
+                for row in tag_doc.neb_website_specifications or []
+            }
 
-        for tag_name in sorted(matched_tags - manual_tags):
+            tag_item_groups = {
+                row.item_group
+                for row in tag_doc.nat_item_groups or []
+                if row.item_group
+            }
+
+            if self.item_group not in tag_item_groups:
+                continue
+
+            if not tag_specs.issubset(item_specs):
+                continue
+
+            if tag_doc.name in manual_tags:
+                continue
+
             self.append("sb_tags", {
-                "sb_tag": tag_name
+                "sb_tag": tag_doc.name
             })
 
     def update_item_inventory_output(self):

--- a/metactical/custom_scripts/item/item.py
+++ b/metactical/custom_scripts/item/item.py
@@ -324,42 +324,60 @@ class CustomItem(Item):
             self.create_item_deletion_log()
             
     def update_sb_tags(self):
-        if not self.neb_website_specifications:
-            return
+        matched_tags = set()
 
-        item_specs = {
-            (row.label, row.description)
-            for row in self.neb_website_specifications
-            if row.label and row.description
-        }
+        if self.item_group:
+            matched_tags.update(
+                frappe.get_all(
+                    "Item Groups List",
+                    filters={
+                        "parenttype": "SB Tag",
+                        "parentfield": "nat_item_groups",
+                        "item_group": self.item_group,
+                    },
+                    pluck="parent",
+                )
+            )
 
-        # ------------------------------------------------
-        # Get all SB Tags
-        # ------------------------------------------------
-        sb_tags = frappe.get_all(
-            "SB Tag",
-            fields=["name"]
-        )
+        for row in self.neb_website_specifications or []:
+            if not row.label or not row.description:
+                continue
 
-        # Clear existing tags with manual_selection = 0
-        self.set("sb_tags", [tag for tag in self.sb_tags if tag.manual_selection])
-        manual_tags = {tag.sb_tag for tag in self.sb_tags if tag.manual_selection}
+            matched_tags.update(
+                frappe.get_all(
+                    "MT Item Website Specification",
+                    filters={
+                        "parenttype": "SB Tag",
+                        "parentfield": "neb_website_specifications",
+                        "label": row.label,
+                        "description": row.description,
+                    },
+                    pluck="parent",
+                )
+            )
 
-        for tag in sb_tags:
-            tag_doc = frappe.get_doc("SB Tag", tag.name)
+            matched_tags.update(
+                tag
+                for tag in frappe.get_all(
+                    "Website Spec Label Descriptions",
+                    filters={
+                        "parent": row.label,
+                        "description": row.description,
+                    },
+                    pluck="sb_tag",
+                )
+                if tag
+            )
 
-            # Convert tag table into set
-            tag_specs = {
-                (row.label, row.description)
-                for row in tag_doc.neb_website_specifications
-                if row.label and row.description
-            }
-            
-            if tag_specs and tag_specs.issubset(item_specs):
-                if tag_doc.name not in manual_tags:
-                    self.append("sb_tags", {
-                        "sb_tag": tag_doc.name
-                    })
+        manual_rows = [tag for tag in self.sb_tags if tag.manual_selection]
+        manual_tags = {tag.sb_tag for tag in manual_rows if tag.sb_tag}
+
+        self.set("sb_tags", manual_rows)
+
+        for tag_name in sorted(matched_tags - manual_tags):
+            self.append("sb_tags", {
+                "sb_tag": tag_name
+            })
 
     def update_item_inventory_output(self):
         # Trigger update for item inventory output if deduct_qty has been updated

--- a/metactical/metactical/doctype/sb_tag/sb_tag.json
+++ b/metactical/metactical/doctype/sb_tag/sb_tag.json
@@ -10,6 +10,8 @@
  "field_order": [
   "hide_in_filters",
   "neb_website_specifications",
+  "section_break_mzif",
+  "nat_item_groups",
   "section_break_sbxf",
   "description"
  ],
@@ -34,12 +36,24 @@
    "fieldtype": "Table",
    "label": "Website Specifications",
    "options": "MT Item Website Specification"
+  },
+  {
+   "fieldname": "section_break_mzif",
+   "fieldtype": "Section Break"
+  },
+  {
+   "allow_bulk_edit": 1,
+   "columns": 2,
+   "fieldname": "nat_item_groups",
+   "fieldtype": "Table MultiSelect",
+   "label": "Item Group",
+   "options": "Item Groups List"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-03 10:05:20.766820",
+ "modified": "2026-04-06 04:29:58.922802",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "SB Tag",


### PR DESCRIPTION
This pull request updates the logic for automatically associating SB Tags with items and introduces a new field to the SB Tag doctype to support filtering by item group. The main goal is to ensure that SB Tags are only auto-assigned when both the website specifications and item group match, and to improve maintainability and clarity in the update logic.

**Enhancements to SB Tag assignment logic:**

- The `update_sb_tags` method in `item.py` now only auto-assigns SB Tags if the item's group is listed in the SB Tag's new `nat_item_groups` field, and the tag's website specifications are a subset of the item's specifications. Manual tags are preserved and not duplicated.

**Schema changes to SB Tag doctype:**

- Added a new `nat_item_groups` field (of type Table MultiSelect, labeled "Item Group") to the `SB Tag` doctype, allowing selection of item groups for each tag. [[1]](diffhunk://#diff-505812dc1d00abbc143595b42ce4d91d9d909d88b164f2c98277050360f1a8d3R13-R14) [[2]](diffhunk://#diff-505812dc1d00abbc143595b42ce4d91d9d909d88b164f2c98277050360f1a8d3R39-R56)
- Inserted a section break (`section_break_mzif`) in the SB Tag form for better UI organization. [[1]](diffhunk://#diff-505812dc1d00abbc143595b42ce4d91d9d909d88b164f2c98277050360f1a8d3R13-R14) [[2]](diffhunk://#diff-505812dc1d00abbc143595b42ce4d91d9d909d88b164f2c98277050360f1a8d3R39-R56)

These changes make SB Tag assignment more precise and configurable, reducing the chance of incorrect tag associations and improving the user experience when managing tags.