### PR TITLE
Update _user_tags in linked document for updates in a Tag and Patch to update existing items

### DIFF
--- a/metactical/custom_scripts/tag/tag.py
+++ b/metactical/custom_scripts/tag/tag.py
@@ -1,5 +1,129 @@
 import frappe
+from frappe.desk.doctype.tag.tag import Tag
 from frappe.desk.doctype.tag.tag import DocTags
+
+class CustomTag(Tag):
+    def after_rename(self, old_name, new_name, merge=False):
+        parent_after_rename = getattr(super(), "after_rename", None)
+        if parent_after_rename:
+            parent_after_rename(old_name, new_name, merge)
+
+        enqueue_sync_linked_user_tags(new_name)
+
+    def on_trash(self):
+        parent_on_trash = getattr(super(), "on_trash", None)
+        if parent_on_trash:
+            parent_on_trash()
+
+        self.flags.user_tag_sync_targets = get_linked_docs(self.name)
+
+    def after_delete(self):
+        parent_after_delete = getattr(super(), "after_delete", None)
+        if parent_after_delete:
+            parent_after_delete()
+
+        enqueue_sync_documents_user_tags(
+            linked_docs=self.flags.user_tag_sync_targets or [],
+            excluded_tags=[self.name],
+        )
+
+
+def enqueue_tag_update(method, **kwargs):
+    frappe.enqueue(
+        method,
+        queue="default",
+        enqueue_after_commit=not frappe.flags.in_test,
+        now=frappe.flags.in_test,
+        **kwargs,
+    )
+
+
+def enqueue_tag_action(action, dt, docs, tags):
+    enqueue_tag_update(
+        process_tag_action,
+        action=action,
+        dt=dt,
+        docs=docs,
+        tags=tags,
+    )
+
+
+def process_tag_action(action, dt, docs, tags):
+    doc_tags = DocTags(dt)
+
+    for docname in docs:
+        if not frappe.db.exists(dt, docname):
+            continue
+
+        for tag in tags:
+            if action == "add":
+                doc_tags.add(docname, tag)
+                add_comment(dt, docname, f" added tag <b>{tag}</b>")
+            elif action == "remove":
+                doc_tags.remove(docname, tag)
+                add_comment(dt, docname, f" removed tag <b>{tag}</b>")
+            else:
+                frappe.throw(f"Unsupported tag action: {action}")
+
+
+def enqueue_sync_linked_user_tags(tag_name):
+    enqueue_tag_update(
+        sync_linked_user_tags,
+        tag_name=tag_name,
+    )
+
+
+def enqueue_sync_documents_user_tags(linked_docs, excluded_tags=None):
+    enqueue_tag_update(
+        sync_documents_user_tags,
+        linked_docs=linked_docs,
+        excluded_tags=excluded_tags or [],
+    )
+
+
+def sync_linked_user_tags(tag_name):
+    sync_documents_user_tags(get_linked_docs(tag_name))
+
+
+def sync_documents_user_tags(linked_docs, excluded_tags=None):
+    for linked_doc in linked_docs:
+        sync_document_user_tags(
+            linked_doc["document_type"],
+            linked_doc["document_name"],
+            excluded_tags=excluded_tags,
+        )
+
+
+def get_linked_docs(tag_name):
+    linked_docs = frappe.get_all(
+        "Tag Link",
+        filters={"tag": tag_name},
+        fields=["document_type", "document_name"],
+        order_by="creation asc",
+    )
+
+    return [
+        {"document_type": linked_doc.document_type, "document_name": linked_doc.document_name}
+        for linked_doc in linked_docs
+    ]
+
+
+def sync_document_user_tags(doctype, docname, excluded_tags=None):
+    if not frappe.db.exists(doctype, docname):
+        return
+
+    excluded_tags = set(excluded_tags or [])
+    current_tags = [
+        tag
+        for tag in frappe.get_all(
+            "Tag Link",
+            filters={"document_type": doctype, "document_name": docname},
+            pluck="tag",
+            order_by="creation asc",
+        )
+        if tag not in excluded_tags
+    ]
+    DocTags(doctype).update(docname, current_tags)
 
 @frappe.whitelist()
 def add_tag(tag, dt, dn, color=None):
@@ -9,8 +133,7 @@ def add_tag(tag, dt, dn, color=None):
     elif not frappe.has_permission("Tag Link", "create"):
         frappe.throw("Insufficient permission to add tags to this document")
     else:
-        DocTags(dt).add(dn, tag)
-        add_comment(dt, dn, f" added tag <b>{tag}</b>")
+        enqueue_tag_action("add", dt, [dn], [tag])
         return tag
 
 @frappe.whitelist()
@@ -27,10 +150,7 @@ def add_tags(tags, dt, docs, color=None):
     if not frappe.has_permission("Tag Link", "create"):
         frappe.throw("Insufficient permission to add tags to this document")
 
-    for doc in docs:
-        for tag in tags:
-            DocTags(dt).add(doc, tag)
-            add_comment(dt, doc, f" added tag <b>{tag}</b>")
+    enqueue_tag_action("add", dt, docs, tags)
 
 @frappe.whitelist()
 def remove_tag(tag, dt, dn):
@@ -38,8 +158,7 @@ def remove_tag(tag, dt, dn):
     if not frappe.has_permission("Tag Link", "delete"):
         frappe.throw("Insufficient permission to remove tags from this document")
     else:
-        DocTags(dt).remove(dn, tag)
-        add_comment(dt, dn, f" removed tag <b>{tag}</b>")
+        enqueue_tag_action("remove", dt, [dn], [tag])
         return tag
     
 def add_comment(dt, dn, comment_text):

--- a/metactical/hooks.py
+++ b/metactical/hooks.py
@@ -196,6 +196,7 @@ override_doctype_class = {
 	"Address": "metactical.custom_scripts.address.address.CustomAddress",
 	"Material Request": "metactical.custom_scripts.material_request.material_request.CustomMaterialRequest",
 	"Item Group": "metactical.custom_scripts.item_group.item_group.CustomItemGroup",
+ 	"Tag": "metactical.custom_scripts.tag.tag.CustomTag",
 }
 
 # Scheduled Tasks

--- a/metactical/patches.txt
+++ b/metactical/patches.txt
@@ -25,5 +25,6 @@ metactical.patches.add_index_to_pick_list_item_sales_order v2
 [post_model_sync]
 execute:frappe.db.sql("UPDATE `tabPick List` SET status = 'Picked' WHERE status='Open' AND docstatus='1'")
 metactical.patches.create_non_formatted_phone
+metactical.patches.repair_item_tag_links_and_user_tags
 
 

--- a/metactical/patches/repair_item_tag_links_and_user_tags.py
+++ b/metactical/patches/repair_item_tag_links_and_user_tags.py
@@ -1,0 +1,145 @@
+from collections import defaultdict
+
+import frappe
+
+def execute():
+	CHUNK_SIZE = 5000
+	start = 0
+
+	while True:
+		item_names = frappe.get_all(
+			"Item",
+			order_by="name asc",
+			start=start,
+			page_length=CHUNK_SIZE,
+			pluck="name"
+		)
+
+		if not item_names:
+			break
+
+		frappe.enqueue(
+			repair_item_tag_links_and_user_tags_chunk,
+			item_names=item_names,
+			queue="default",
+			timeout=3600
+		)
+
+		start += CHUNK_SIZE
+
+
+def repair_item_tag_links_and_user_tags_chunk(item_names):
+	if not item_names:
+		return
+
+	items = frappe.get_all(
+		"Item",
+		filters={"name": ("in", item_names)},
+		fields=["name", "item_name", "_user_tags"],
+	)
+
+	if not items:
+		return
+
+	items_by_name = {item.name: item for item in items}
+	tag_links_by_item = defaultdict(list)
+	candidate_tags = set()
+	user_tags_by_item = {}
+
+	for item in items:
+		user_tags = parse_user_tags(item._user_tags)
+		user_tags_by_item[item.name] = user_tags
+		candidate_tags.update(user_tags)
+
+	tag_links = frappe.get_all(
+		"Tag Link",
+		filters={"document_type": "Item", "document_name": ("in", list(items_by_name))},
+		fields=["name", "document_name", "tag"],
+		order_by="creation asc",
+	)
+
+	for tag_link in tag_links:
+		tag_links_by_item[tag_link.document_name].append(tag_link)
+		if tag_link.tag:
+			candidate_tags.add(tag_link.tag)
+
+	valid_tags = get_valid_tags(candidate_tags)
+
+	for item_name in item_names:
+		item = items_by_name.get(item_name)
+		if not item:
+			continue
+
+		final_tags = merge_valid_tags(
+			user_tags_by_item.get(item_name, []),
+			[tag_link.tag for tag_link in tag_links_by_item.get(item_name, [])],
+			valid_tags,
+		)
+		reconcile_item_tags(item, tag_links_by_item.get(item_name, []), final_tags)
+
+	frappe.db.commit()
+
+
+def parse_user_tags(user_tags):
+	return [tag.strip() for tag in (user_tags or "").split(",") if tag and tag.strip()]
+
+
+def get_valid_tags(candidate_tags):
+	if not candidate_tags:
+		return set()
+
+	return set(frappe.get_all("Tag", filters={"name": ("in", list(candidate_tags))}, pluck="name"))
+
+
+def merge_valid_tags(user_tags, tag_link_tags, valid_tags):
+	merged_tags = []
+	seen_tags = set()
+
+	# Keep any valid tag that survived on either side instead of dropping it during repair.
+	for tag in [*user_tags, *tag_link_tags]:
+		if tag not in valid_tags or tag in seen_tags:
+			continue
+
+		merged_tags.append(tag)
+		seen_tags.add(tag)
+
+	return merged_tags
+
+
+def reconcile_item_tags(item, tag_links, final_tags):
+	final_tag_set = set(final_tags)
+	rows_to_delete = []
+	existing_tags = set()
+
+	for tag_link in tag_links:
+		if tag_link.tag not in final_tag_set or tag_link.tag in existing_tags:
+			rows_to_delete.append(tag_link.name)
+			continue
+
+		existing_tags.add(tag_link.tag)
+
+	if rows_to_delete:
+		frappe.db.delete("Tag Link", {"name": ("in", rows_to_delete)})
+
+	missing_tags = [tag for tag in final_tags if tag not in existing_tags]
+	for tag in missing_tags:
+		frappe.get_doc(
+			{
+				"doctype": "Tag Link",
+				"document_type": "Item",
+				"document_name": item.name,
+				"tag": tag,
+				"title": item.item_name or item.name,
+			}
+		).insert(ignore_permissions=True)
+
+	desired_user_tags = build_user_tags_value(final_tags)
+	if (item._user_tags or "") != desired_user_tags:
+		frappe.db.set_value("Item", item.name, "_user_tags", desired_user_tags, update_modified=False)
+
+
+def build_user_tags_value(tags):
+	if not tags:
+		return ""
+
+	return "," + ",".join(tags)


### PR DESCRIPTION
### What is Done
- Keep document tag links and saved user tags synchronized
- Queue tag add and remove actions in the background
- Support tag rename, merge, and delete without leaving stale tag data behind
- Add a repair patch for broken Item tag data
  - Process Item repairs in chunks of 5000 records at a time
  - Enqueue each repair batch so the cleanup runs in the background
  - Remove invalid tag links that reference tags that no longer exist
  - Remove duplicate tag links on Items
  - Rebuild the final saved user tags from valid and cleaned tag data only