### PR TITLE
Apply USD Default Currency and PKR Conversion Override in BOM

### DIFF
--- a/metactical/custom_scripts/bom/bom.js
+++ b/metactical/custom_scripts/bom/bom.js
@@ -16,6 +16,7 @@ frappe.ui.form.on("BOM", {
   //         }
   //     }
   // })
+    default_currency_for_pkr_company(frm);
     apply_usd_pkr_override(frm, "refresh");
   },
   currency: function(frm){
@@ -25,6 +26,7 @@ frappe.ui.form.on("BOM", {
     apply_usd_pkr_override(frm, "conversion_rate");
   },
   company: function(frm){
+    default_currency_for_pkr_company(frm);
     apply_usd_pkr_override(frm, "company");
   }
 })
@@ -32,6 +34,16 @@ frappe.ui.form.on("BOM", {
 var get_company_currency = function(company) {
   return frappe.db.get_value("Company", company, "default_currency").then(r => {
     return r && r.message ? r.message.default_currency : null;
+  });
+};
+
+// On new BOMs for a PKR company, default the BOM currency to USD.
+// Skip on saved docs so we never overwrite a user's choice.
+var default_currency_for_pkr_company = function(frm) {
+  get_company_currency(frm.doc.company).then(company_currency => {
+    if (company_currency === "PKR" && frm.doc.currency !== "USD") {
+      frm.set_value("currency", "USD");
+    }
   });
 };
 

--- a/metactical/custom_scripts/bom/bom.js
+++ b/metactical/custom_scripts/bom/bom.js
@@ -16,8 +16,35 @@ frappe.ui.form.on("BOM", {
   //         }
   //     }
   // })
+    apply_usd_pkr_override(frm, "refresh");
+  },
+  currency: function(frm){
+    apply_usd_pkr_override(frm, "currency");
+  },
+  conversion_rate: function(frm){
+    apply_usd_pkr_override(frm, "conversion_rate");
+  },
+  company: function(frm){
+    apply_usd_pkr_override(frm, "company");
   }
 })
+
+var get_company_currency = function(company) {
+  return frappe.db.get_value("Company", company, "default_currency").then(r => {
+    return r && r.message ? r.message.default_currency : null;
+  });
+};
+
+var apply_usd_pkr_override = function(frm, source) {
+  get_company_currency(frm.doc.company).then(company_currency => {
+    if (frm.doc.currency === "USD" && company_currency === "PKR") {
+      if (flt(frm.doc.conversion_rate) !== 280) {
+        frm.set_value("conversion_rate", 280);
+      }
+      return;
+    }
+  });
+};
 
 frappe.ui.form.on("BOM Operation", {
   time_in_mins: function (frm, cdt, cdn) {


### PR DESCRIPTION
This pull request introduces enhancements to the BOM form logic to better handle scenarios where the company currency is PKR. The main improvements are automatic defaulting of the BOM currency to USD for PKR companies and enforcing a fixed USD to PKR conversion rate. These changes help ensure consistency and reduce manual errors when creating or editing BOMs for PKR-based companies.

Currency and conversion rate automation:

* Automatically sets the BOM currency to USD when a new BOM is created for a company whose default currency is PKR, unless the user has already chosen a different currency.
* Forces the conversion rate to 280 when the BOM currency is USD and the company currency is PKR, regardless of how the currency or conversion rate fields are changed.

Supporting functions:

* Adds helper functions `get_company_currency`, `default_currency_for_pkr_company`, and `apply_usd_pkr_override` to encapsulate the new logic and ensure it's applied consistently on form refresh and relevant field changes.