### PR TITLE
PPS API - to create pick list, delivery note, packing slip and shipment

### DIFF
--- a/metactical/custom_scripts/utils/pps_api.py
+++ b/metactical/custom_scripts/utils/pps_api.py
@@ -1,108 +1,404 @@
+import random
 import frappe
+from frappe.utils import add_days, nowdate
 from metactical.custom_scripts.pick_list.pick_list import create_pick_list
+from erpnext.stock.doctype.delivery_note.delivery_note import make_packing_slip
+import json
+
+def _get_random_instock_items(warehouse, count):
+    """Return `count` random items that have actual_qty >= 1 in `warehouse`."""
+    rows = frappe.db.sql("""
+        SELECT b.item_code, b.actual_qty, i.standard_rate
+        FROM `tabBin` b
+        JOIN `tabItem` i ON i.name = b.item_code
+        WHERE b.warehouse = %(warehouse)s
+          AND b.actual_qty >= 1
+          AND i.disabled = 0
+          AND i.is_stock_item = 1
+        ORDER BY RAND()
+        LIMIT %(count)s
+    """, {"warehouse": warehouse, "count": count}, as_dict=True)
+    return rows
+
+
+@frappe.whitelist()
+def create_sales_order(*args, **kwargs):
+    """
+    Create and submit a Sales Order using random in-stock items.
+
+    Required: customer
+    Optional: company, warehouse, item_count (default 2), delivery_date,
+              shipping_address_name, taxes_and_charges, source
+    """
+    try:
+        form_data = dict(frappe.form_dict)
+
+        customer = form_data.get("customer")
+  
+        company = form_data.get("company") or frappe.db.get_single_value("Global Defaults", "default_company")
+        warehouse = form_data.get("warehouse") or "R01-Gor-Active Stock - ICL"
+        item_count = int(form_data.get("item_count") or 5)
+
+        stock_items = _get_random_instock_items(warehouse, item_count)
+        if not stock_items:
+            return {"status": "error", "message": f"No in-stock items found in warehouse {warehouse}."}
+
+        company_currency = frappe.get_cached_value("Company", company, "default_currency") or "CAD"
+
+        so = frappe.new_doc("Sales Order")
+        so.company = company
+        so.customer = "CS-25-00099"
+        so.currency = company_currency
+        so.set("company_currency", company_currency)
+        so.conversion_rate = 1
+        so.source = "Store - Camo - Edmonds"
+        so.shipping_address_name = "CS-25-00117-Shipping"
+        so.customer_address = "_Test PPS Shipping Address-9"
+        so.taxes_and_charges = "Alberta - ICL"
+        so.exchange_rate = 1
+        so.transaction_date = nowdate()
+        so.delivery_date = form_data.get("delivery_date") or add_days(nowdate(), 7)
+
+        if form_data.get("taxes_and_charges"):
+            so.taxes_and_charges = form_data.get("taxes_and_charges")
+        if form_data.get("source"):
+            so.source = form_data.get("source")
+
+        for stock_item in stock_items:
+            so.append("items", {
+                "item_code": stock_item.item_code,
+                "warehouse": warehouse,
+                "qty": 1,
+                "rate": stock_item.standard_rate or 0,
+            })
+
+        so.set_missing_values()
+        so.insert(ignore_permissions=True)
+        so.submit()
+        frappe.db.commit()
+
+        packing_slips = []
+        for idx, item in enumerate(so.items, start=1):
+            packing_slips.append({
+                "parcel_template": f"BOX 1",
+                "dimensions": {"height": 1, "width": 2, "length": 0},
+                "weight": 0,
+                "items": [{
+                    "item_code": item.item_code,
+                    "quantity": int(item.qty),
+                    "sales_order_item": item.name,
+                }],
+            })
+
+        return {
+            "order_id": so.name,
+            "packing_slips": packing_slips,
+        }
+
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), "Error creating sales order")
+        return {
+            "status": "error",
+            "message": str(e),
+        }
+
 
 @frappe.whitelist()
 def pack_order(*args, **kwargs):
     """
-    Packs an order by calling the appropriate method in the PPS API.
+    Packs an order using nested packing_slips payload structure.
     """
+
+    order_id = None
+    log = None
     try:
         form_data = dict(frappe.form_dict)
-        
+        log = create_log(form_data, "Pack Order")
         order_id = form_data.get("order_id")
         if not order_id:
-            return {"status": "error", "message": "Order ID is required to pack an order."}
-        
-        
-        items = form_data.get("items")
-        # items list will be in the format: [{"item_code": "ITEM001", "quantity": 2, "sales_order_item": "SOI-00001"}, ...]
-        
-        validation_errors = validate_items(items, order_id)
-        if validation_errors:
-            return {"status": "error", "message": "; ".join(validation_errors)}
-        
-        
-        create_pick_list_response = create_pick_list_for_order(order_id, items)
-        print(f"Create pick list response: {create_pick_list_response}")
-        if not create_pick_list_response.get("success"):
-            return {"status": "error", "message": f"Failed to create pick list for order {order_id}: {create_pick_list_response.get('error')}"}
-        
-        
-        # Assuming you have a method in your PPS API to pack an order
-        response = call_pps_api_to_pack_order(order_id)
-        if response.get("success"):
-            return {"status": "success", "message": f"Order {order_id} packed successfully."}
-        else:
-            return {"status": "error", "message": f"Failed to pack order {order_id}: {response.get('error')}"}
-    except Exception as e:
-        frappe.log_error(frappe.get_traceback(), f"Error packing order {order_id}")
-        return {"status": "error", "message": f"An error occurred while packing order {order_id}: {str(e)}"}
-    
-def call_pps_api_to_pack_order(order_id):
-    """
-    Placeholder function to call the PPS API to pack an order.
-    Replace this with actual API call logic.
-    """
-    # Example response from the PPS API
-    return {"success": True}
+            return {
+                "status": "error",
+                "message": "Order ID is required."
+            }
 
-def validate_items(items, order_id):
+        packing_slips = form_data.get("packing_slips") or []
+        if not packing_slips:
+            return {
+                "status": "error",
+                "message": "Packing slips are required."
+            }
+
+        validation_errors = validate_packing_slips(
+            packing_slips,
+            order_id
+        )
+
+        if validation_errors:
+            return {
+                "status": "error",
+                "message": "; ".join(validation_errors)
+            }
+
+        items = flatten_packing_slip_items(packing_slips)
+        pick_list_result = create_pick_list_for_order(
+            order_id,
+            items
+        )
+
+        if not pick_list_result.get("success"):
+            frappe.db.rollback()
+            frappe.db.set_value("PPS API Log", log, "error", json.dumps({
+                "status": "error",
+                "message": pick_list_result.get("error")
+            }))
+            
+            return {
+                "status": "error",
+                "message": pick_list_result.get("error")
+            }
+
+        pick_list = frappe.get_doc("Pick List", pick_list_result.get("pick_list"))
+        frappe.db.set_value("PPS API Log", log, "pick_list", pick_list.name)
+
+        packing_slip_docs, dn = create_packing_slips(pick_list, packing_slips)        
+        frappe.db.set_value("PPS API Log", log, {
+            "delivery_note": dn,
+            "packing_slips": ", ".join([str(slip) for slip in packing_slip_docs])
+        })
+        
+        frappe.db.commit()
+
+        return {
+            "status": "success",
+            "message": f"Order {order_id} packed successfully.",
+            "pick_list": pick_list.name,
+            "delivery_note": dn,
+            "packing_slips": packing_slip_docs
+        }
+
+    except Exception as e:
+        frappe.get_traceback()
+        if log:
+            frappe.db.set_value("PPS API Log", log, "error", json.dumps({
+                "status": "error",
+                "message": str(e)
+            }))
+            
+        frappe.log_error(message=frappe.get_traceback(), title=f"Error packing order {order_id}")
+        frappe.db.commit()
+        
+        return {
+            "status": "error",
+            "message": str(e)
+        }
+
+
+def flatten_packing_slip_items(packing_slips):
     """
-    Validates the items being packed against the sales order.
+    Extract all items from packing slips into a flat list.
     """
+
+    items = []
+
+    for slip in packing_slips:
+        for item in slip.get("items", []):
+            items.append(item)
+
+    return items
+
+
+def validate_packing_slips(packing_slips, order_id):
+    """
+    Validate packing slip payload.
+    """
+
     errors = []
-    for item in items:
-        item_code = item.get("item_code")
-        quantity = item.get("quantity")
-        sales_order_item = item.get("sales_order_item")
-        
-        if not item_code or not quantity or not sales_order_item:
-            errors.append(f"Item {item_code} is missing required fields.")
+
+    for index, slip in enumerate(packing_slips, start=1):
+
+        items = slip.get("items") or []
+
+        if not items:
+            errors.append(
+                f"Packing slip {index} has no items."
+            )
             continue
-        
-        # Validate that the item exists in the sales order
-        so_item = frappe.db.get_value("Sales Order Item", {"name": sales_order_item, "parent": order_id}, ["item_code", "qty"], as_dict=True)
-        if not so_item:
-            errors.append(f"Sales Order Item {sales_order_item} does not exist for Order {order_id}.")
-            continue
-        
-        if so_item.item_code != item_code:
-            errors.append(f"Item code {item_code} does not match Sales Order Item {so_item.item_code}.")
-        
-        if quantity > so_item.qty:
-            errors.append(f"Quantity {quantity} for item {item_code} exceeds quantity in Sales Order Item {so_item.item_code}.")
-    
+
+        for item in items:
+
+            item_code = item.get("item_code")
+            quantity = item.get("quantity")
+            sales_order_item = item.get("sales_order_item")
+
+            if not sales_order_item:
+                errors.append(
+                    f"Missing sales_order_item in packing slip {index}."
+                )
+                continue
+
+            if not quantity or quantity <= 0:
+                errors.append(
+                    f"Invalid quantity for item {sales_order_item}."
+                )
+                continue
+
+            so_item = frappe.db.get_value(
+                "Sales Order Item",
+                {
+                    "name": sales_order_item,
+                    "parent": order_id
+                },
+                ["item_code", "qty"],
+                as_dict=True
+            )
+
+            if not so_item:
+                errors.append(
+                    f"Sales Order Item {sales_order_item} does not exist in order {order_id}."
+                )
+                continue
+
+            if item_code and so_item.item_code != item_code:
+                errors.append(
+                    f"Item code mismatch for SO Item {sales_order_item}."
+                )
+
+            if quantity > so_item.qty:
+                errors.append(
+                    f"Quantity {quantity} exceeds ordered qty for {sales_order_item}."
+                )
+
     return errors
+
 
 def create_pick_list_for_order(order_id, items):
     """
-    Creates a pick list for the order using the provided items.
+    Create pick list using provided quantities.
     """
-    try:
-        pick_list = create_pick_list(source_name=order_id)
-        items_dict = {i["sales_order_item"]: i for i in items}
-        locations = []
-        
-        for item in pick_list.locations:
-            item_code = item.get("item_code")
-            quantity = item.get("qty")
-            sales_order_item = item.get("sales_order_item")
-            
-            print(f"Processing item in pick list: {item_code}, quantity: {quantity}, sales_order_item: {sales_order_item}")
-            if not item_code or not quantity or not sales_order_item:
-                continue
-            
-            if sales_order_item in items_dict:
-                locations.append(item)
-                
-        if not locations:
-            return {"success": False, "error": "No valid items found to create pick list."}
-        
-        pick_list.locations = locations
-        pick_list.save()
-        frappe.db.commit()
 
-        return {"success": True, "pick_list": pick_list.name}
+    try:
+
+        pick_list = create_pick_list(
+            source_name=order_id
+        )
+
+        items_dict = {
+            i["sales_order_item"]: i
+            for i in items
+        }
+
+        valid_locations = []
+
+        for location in pick_list.locations:
+
+            sales_order_item = location.get("sales_order_item")
+
+            if sales_order_item not in items_dict:
+                continue
+
+            item_data = items_dict[sales_order_item]
+
+            location.qty = item_data["quantity"]
+
+            valid_locations.append(location)
+
+        if not valid_locations:
+            return {
+                "success": False,
+                "error": "No valid items found for pick list."
+            }
+
+        pick_list.locations = valid_locations
+        
+        pick_list.save()
+        pick_list.submit()
+
+        return {
+            "success": True,
+            "pick_list": pick_list.name
+        }
+
     except Exception as e:
-        frappe.log_error(frappe.get_traceback(), f"Error creating pick list for order {order_id}")
-        return {"success": False, "error": str(e)}
+        frappe.log_error(message=frappe.get_traceback(), title=f"Error creating pick list for order {order_id}")
+
+        return {
+            "success": False,
+            "error": str(e)
+        }
+
+def create_packing_slips(pick_list, packing_slips):
+    """
+    Create ERPNext packing slips.
+    """
+
+    print("Creating packing slips in ERPNext...")
+    print(f"Pick List: {pick_list.name}")
+    print(f"Packing Slips Payload: {packing_slips}")
+
+    delivery_notes = frappe.db.sql("""
+        SELECT DISTINCT parent
+        FROM `tabDelivery Note Item`
+        WHERE against_pick_list = %s
+    """, (pick_list.name,), as_dict=True)
+    
+    delivery_note = delivery_notes[0]["parent"] if delivery_notes else None
+    
+    if not delivery_note:
+        frappe.throw(
+            f"No Delivery Note found for Pick List {pick_list.name}"
+        )
+
+    delivery_note = delivery_notes[0]["parent"]
+    print(f"Using Delivery Note: {delivery_note} for packing slips.")
+
+    created_slips = []
+    case_no = 1
+
+    for slip in packing_slips:
+
+        packing_slip_doc = make_packing_slip(delivery_note)
+        items = []
+        for dn_item in packing_slip_doc.items:
+            for slip_item in slip.get("items", []):
+                if dn_item.item_code == slip_item.get("item_code"):
+                    dn_item.qty = slip_item.get("quantity")
+                    dn_item.sales_order_item = slip_item.get("sales_order_item")
+                    items.append(dn_item)
+                    
+
+        dimensions = slip.get("dimensions") or {}
+
+        packing_slip_doc.update({
+            "from_case_no": case_no,
+            "to_case_no": case_no,
+            "gross_weight_pkg": slip.get("weight"),
+            "net_weight_pkg": slip.get("weight"),
+            "custom_neb_box_height": dimensions.get("height"),
+            "custom_neb_box_width": dimensions.get("width"),
+            "custom_neb_box_length": dimensions.get("length"),
+            "custom_neb_parcel_template": slip.get("parcel_template"),
+            "items": items
+        })
+
+        packing_slip_doc.insert()
+        packing_slip_doc.submit()
+
+        created_slips.append(packing_slip_doc.name)
+        case_no += 1
+
+    return created_slips, delivery_note
+
+
+def create_log(form_data, request_type):
+    try:
+        log = frappe.get_doc({
+            'doctype': 'PPS API Log',
+            'request_type': request_type,
+            'payload': json.dumps(form_data),
+        })
+        log.insert(ignore_permissions=True)
+        frappe.db.commit()
+        return log.name
+    except Exception as e:
+        frappe.log_error(title='POS API Log Error', message=frappe.get_traceback())
+        

--- a/metactical/custom_scripts/utils/pps_api.py
+++ b/metactical/custom_scripts/utils/pps_api.py
@@ -4,6 +4,10 @@ from frappe.utils import add_days, nowdate
 from metactical.custom_scripts.pick_list.pick_list import create_pick_list
 from erpnext.stock.doctype.delivery_note.delivery_note import make_packing_slip
 import json
+from metactical.utils.shipping.shipping import get_rate
+from concurrent.futures import ThreadPoolExecutor
+
+site = frappe.local.site
 
 def _get_random_instock_items(warehouse, count):
     """Return `count` random items that have actual_qty >= 1 in `warehouse`."""
@@ -37,7 +41,7 @@ def create_sales_order(*args, **kwargs):
   
         company = form_data.get("company") or frappe.db.get_single_value("Global Defaults", "default_company")
         warehouse = form_data.get("warehouse") or "R01-Gor-Active Stock - ICL"
-        item_count = int(form_data.get("item_count") or 5)
+        item_count = int(form_data.get("item_count") or 2)
 
         stock_items = _get_random_instock_items(warehouse, item_count)
         if not stock_items:
@@ -82,7 +86,7 @@ def create_sales_order(*args, **kwargs):
             packing_slips.append({
                 "parcel_template": f"BOX 1",
                 "dimensions": {"height": 1, "width": 2, "length": 0},
-                "weight": 0,
+                "weight": 1,
                 "items": [{
                     "item_code": item.item_code,
                     "quantity": int(item.qty),
@@ -108,90 +112,129 @@ def pack_order(*args, **kwargs):
     """
     Packs an order using nested packing_slips payload structure.
     """
+    form_data = dict(frappe.form_dict)
+    log = create_log(form_data, "Pack Order")
+    order_id = form_data.get("order_id")
 
-    order_id = None
-    log = None
     try:
-        form_data = dict(frappe.form_dict)
-        log = create_log(form_data, "Pack Order")
-        order_id = form_data.get("order_id")
+        # --- Validate input ---
         if not order_id:
-            return {
-                "status": "error",
-                "message": "Order ID is required."
-            }
+            return _error("Order ID is required.")
 
         packing_slips = form_data.get("packing_slips") or []
         if not packing_slips:
-            return {
-                "status": "error",
-                "message": "Packing slips are required."
-            }
+            return _error("Packing slips are required.")
 
-        validation_errors = validate_packing_slips(
-            packing_slips,
-            order_id
-        )
-
+        validation_errors = validate_packing_slips(packing_slips, order_id)
         if validation_errors:
-            return {
-                "status": "error",
-                "message": "; ".join(validation_errors)
-            }
+            return _error("; ".join(validation_errors))
 
+        # --- Create pick list ---
         items = flatten_packing_slip_items(packing_slips)
-        pick_list_result = create_pick_list_for_order(
-            order_id,
-            items
-        )
+        pick_list_result = create_pick_list_for_order(order_id, items)
 
         if not pick_list_result.get("success"):
-            frappe.db.rollback()
-            frappe.db.set_value("PPS API Log", log, "error", json.dumps({
-                "status": "error",
-                "message": pick_list_result.get("error")
-            }))
-            
-            return {
-                "status": "error",
-                "message": pick_list_result.get("error")
-            }
+            return _fail_with_log(log, pick_list_result.get("error"))
 
-        pick_list = frappe.get_doc("Pick List", pick_list_result.get("pick_list"))
+        pick_list = frappe.get_doc("Pick List", pick_list_result["pick_list"])
         frappe.db.set_value("PPS API Log", log, "pick_list", pick_list.name)
 
-        packing_slip_docs, dn = create_packing_slips(pick_list, packing_slips)        
+        # --- Create packing slips + delivery note ---
+        packing_slip_docs, dn = create_packing_slips(pick_list, packing_slips)
         frappe.db.set_value("PPS API Log", log, {
             "delivery_note": dn,
-            "packing_slips": ", ".join([str(slip) for slip in packing_slip_docs])
+            "packing_slips": ", ".join(str(s) for s in packing_slip_docs),
         })
-        
+
+        # --- Resolve shipment ---
+        shipment_name = _get_shipment_for_delivery_note(dn)
+        if not shipment_name:
+            return _fail_with_log(log, f"No shipment found for Delivery Note {dn}")
+
+        # Trigger parcel auto-population
+        frappe.get_doc("Shipment", shipment_name).save(ignore_permissions=True)
         frappe.db.commit()
 
-        return {
+        # --- Fetch shipping rates concurrently ---
+        rates = _fetch_rates_concurrently(shipment_name)
+        response = {
             "status": "success",
             "message": f"Order {order_id} packed successfully.",
             "pick_list": pick_list.name,
             "delivery_note": dn,
-            "packing_slips": packing_slip_docs
+            "shipment": shipment_name,
+            "canada_post": rates.get("Canada Post"),
+            "purolator": rates.get("Purolator"),
+            "packing_slips": packing_slip_docs,
         }
-
-    except Exception as e:
-        frappe.get_traceback()
-        if log:
-            frappe.db.set_value("PPS API Log", log, "error", json.dumps({
-                "status": "error",
-                "message": str(e)
-            }))
-            
-        frappe.log_error(message=frappe.get_traceback(), title=f"Error packing order {order_id}")
+        
+        frappe.db.set_value("PPS API Log", log, "response", json.dumps(response))
         frappe.db.commit()
         
-        return {
-            "status": "error",
-            "message": str(e)
-        }
+        return response
 
+    except Exception as e:
+        frappe.log_error(message=frappe.get_traceback(), title=f"Error packing order {order_id}")
+        if log:
+            frappe.db.set_value("PPS API Log", log, "error", json.dumps(_error(str(e))))
+        frappe.db.commit()
+        return _error(str(e))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _error(message: str) -> dict:
+    return {"status": "error", "message": message}
+
+
+def _fail_with_log(log, message: str) -> dict:
+    frappe.db.rollback()
+    if log:
+        frappe.db.set_value("PPS API Log", log, "error", json.dumps(_error(message)))
+    return _error(message)
+
+
+def _get_shipment_for_delivery_note(dn: str) -> str | None:
+    rows = frappe.db.sql(
+        """
+        SELECT parent
+        FROM `tabShipment Delivery Note`
+        WHERE delivery_note = %s
+        LIMIT 1
+        """,
+        (dn,),
+        as_dict=True,
+    )
+    return rows[0]["parent"] if rows else None
+
+
+def _fetch_rates_concurrently(shipment_name: str) -> dict:
+    providers = ["Canada Post", "Purolator"]
+    results = {}
+
+    def get_rate_threadsafe(provider):
+        frappe.init(site=site)
+        frappe.connect()
+        try:
+            return get_rate(name=shipment_name, provider=provider)
+        finally:
+            frappe.destroy()
+
+    with ThreadPoolExecutor(max_workers=len(providers)) as executor:
+        futures = {p: executor.submit(get_rate_threadsafe, p) for p in providers}
+        for provider, future in futures.items():
+            try:
+                results[provider] = future.result()
+            except Exception:
+                frappe.log_error(
+                    title=f"{provider} Rate Error",
+                    message=frappe.get_traceback(),
+                )
+                results[provider] = None
+
+    return results
 
 def flatten_packing_slip_items(packing_slips):
     """

--- a/metactical/custom_scripts/utils/pps_api.py
+++ b/metactical/custom_scripts/utils/pps_api.py
@@ -1,0 +1,108 @@
+import frappe
+from metactical.custom_scripts.pick_list.pick_list import create_pick_list
+
+@frappe.whitelist()
+def pack_order(*args, **kwargs):
+    """
+    Packs an order by calling the appropriate method in the PPS API.
+    """
+    try:
+        form_data = dict(frappe.form_dict)
+        
+        order_id = form_data.get("order_id")
+        if not order_id:
+            return {"status": "error", "message": "Order ID is required to pack an order."}
+        
+        
+        items = form_data.get("items")
+        # items list will be in the format: [{"item_code": "ITEM001", "quantity": 2, "sales_order_item": "SOI-00001"}, ...]
+        
+        validation_errors = validate_items(items, order_id)
+        if validation_errors:
+            return {"status": "error", "message": "; ".join(validation_errors)}
+        
+        
+        create_pick_list_response = create_pick_list_for_order(order_id, items)
+        print(f"Create pick list response: {create_pick_list_response}")
+        if not create_pick_list_response.get("success"):
+            return {"status": "error", "message": f"Failed to create pick list for order {order_id}: {create_pick_list_response.get('error')}"}
+        
+        
+        # Assuming you have a method in your PPS API to pack an order
+        response = call_pps_api_to_pack_order(order_id)
+        if response.get("success"):
+            return {"status": "success", "message": f"Order {order_id} packed successfully."}
+        else:
+            return {"status": "error", "message": f"Failed to pack order {order_id}: {response.get('error')}"}
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), f"Error packing order {order_id}")
+        return {"status": "error", "message": f"An error occurred while packing order {order_id}: {str(e)}"}
+    
+def call_pps_api_to_pack_order(order_id):
+    """
+    Placeholder function to call the PPS API to pack an order.
+    Replace this with actual API call logic.
+    """
+    # Example response from the PPS API
+    return {"success": True}
+
+def validate_items(items, order_id):
+    """
+    Validates the items being packed against the sales order.
+    """
+    errors = []
+    for item in items:
+        item_code = item.get("item_code")
+        quantity = item.get("quantity")
+        sales_order_item = item.get("sales_order_item")
+        
+        if not item_code or not quantity or not sales_order_item:
+            errors.append(f"Item {item_code} is missing required fields.")
+            continue
+        
+        # Validate that the item exists in the sales order
+        so_item = frappe.db.get_value("Sales Order Item", {"name": sales_order_item, "parent": order_id}, ["item_code", "qty"], as_dict=True)
+        if not so_item:
+            errors.append(f"Sales Order Item {sales_order_item} does not exist for Order {order_id}.")
+            continue
+        
+        if so_item.item_code != item_code:
+            errors.append(f"Item code {item_code} does not match Sales Order Item {so_item.item_code}.")
+        
+        if quantity > so_item.qty:
+            errors.append(f"Quantity {quantity} for item {item_code} exceeds quantity in Sales Order Item {so_item.item_code}.")
+    
+    return errors
+
+def create_pick_list_for_order(order_id, items):
+    """
+    Creates a pick list for the order using the provided items.
+    """
+    try:
+        pick_list = create_pick_list(source_name=order_id)
+        items_dict = {i["sales_order_item"]: i for i in items}
+        locations = []
+        
+        for item in pick_list.locations:
+            item_code = item.get("item_code")
+            quantity = item.get("qty")
+            sales_order_item = item.get("sales_order_item")
+            
+            print(f"Processing item in pick list: {item_code}, quantity: {quantity}, sales_order_item: {sales_order_item}")
+            if not item_code or not quantity or not sales_order_item:
+                continue
+            
+            if sales_order_item in items_dict:
+                locations.append(item)
+                
+        if not locations:
+            return {"success": False, "error": "No valid items found to create pick list."}
+        
+        pick_list.locations = locations
+        pick_list.save()
+        frappe.db.commit()
+
+        return {"success": True, "pick_list": pick_list.name}
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), f"Error creating pick list for order {order_id}")
+        return {"success": False, "error": str(e)}

--- a/metactical/custom_scripts/utils/test_pps_api.py
+++ b/metactical/custom_scripts/utils/test_pps_api.py
@@ -1,0 +1,400 @@
+# Copyright (c) 2024, Techlift Technologies and Contributors
+# See license.txt
+
+import unittest
+from unittest.mock import MagicMock, patch
+import frappe
+from frappe.utils import add_days, nowdate
+
+import metactical.custom_scripts.utils.pps_api as pps_api
+from metactical.custom_scripts.utils.pps_api import (
+    pack_order,
+    flatten_packing_slip_items,
+    validate_packing_slips,
+    create_pick_list_for_order,
+)
+
+
+def make_test_sales_order(item_list=None):
+    """Create and submit a test Sales Order with a shipping address."""
+    customer = "CS-25-00099"
+
+    # Ensure a shipping address exists for the customer
+    address_name = "CS-25-00117-Shipping"
+    if not frappe.db.exists("Address", address_name):
+        addr = frappe.get_doc({
+            "doctype": "Address",
+            "address_title": "_Test PPS Shipping Address",
+            "address_type": "Shipping",
+            "address_line1": "123 Test Street",
+            "city": "Test City",
+            "country": "Canada",
+            "links": [{"link_doctype": "Customer", "link_name": customer}],
+        })
+        addr.insert(ignore_permissions=True)
+
+    company = "International Camouflage Ltd"
+    company_currency = frappe.get_cached_value("Company", company, "default_currency") or "CAD"
+
+    so = frappe.new_doc("Sales Order")
+    so.company = company
+    so.customer = customer
+    so.currency = company_currency
+    so.set("company_currency", company_currency)
+    so.conversion_rate = 1
+    so.exchange_rate = 1
+    so.transaction_date = nowdate()
+    so.delivery_date = add_days(nowdate(), 7)
+    so.shipping_address_name = address_name
+    so.taxes_and_charges = "Alberta - ICL"
+    so.source = "Website - Gorilla"
+
+    if item_list:
+        for item in item_list:
+            so.append("items", item)
+    else:
+        so.append("items", {
+            "item_code": "RFIWPG130-1",
+            "warehouse": "R01-Gor-Active Stock - ICL",
+            "qty": 2,
+            "rate": 100,
+        })
+
+    so.set_missing_values()
+    so.insert(ignore_permissions=True)
+    so.submit()
+    return so
+
+
+class TestFlattenPackingSlipItems(unittest.TestCase):
+    def test_single_slip_single_item(self):
+        packing_slips = [{
+            "items": [{"item_code": "ITEM-001", "quantity": 1, "sales_order_item": "abc123"}]
+        }]
+        result = flatten_packing_slip_items(packing_slips)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["item_code"], "ITEM-001")
+
+    def test_multiple_slips_multiple_items(self):
+        packing_slips = [
+            {"items": [
+                {"item_code": "A", "quantity": 1, "sales_order_item": "a1"},
+                {"item_code": "B", "quantity": 2, "sales_order_item": "b1"},
+            ]},
+            {"items": [
+                {"item_code": "C", "quantity": 3, "sales_order_item": "c1"},
+            ]},
+        ]
+        result = flatten_packing_slip_items(packing_slips)
+        self.assertEqual(len(result), 3)
+
+    def test_empty_packing_slips(self):
+        self.assertEqual(flatten_packing_slip_items([]), [])
+
+    def test_slip_with_no_items_key(self):
+        result = flatten_packing_slip_items([{"parcel_template": "BOX 1"}])
+        self.assertEqual(result, [])
+
+
+class TestValidatePackingSlips(unittest.TestCase):
+    def setUp(self):
+        # Mock frappe.db.get_value to avoid hitting the DB in unit tests
+        self.patcher = patch("metactical.custom_scripts.utils.pps_api.frappe")
+        self.mock_frappe = self.patcher.start()
+        self.mock_frappe.db.get_value.return_value = frappe._dict({
+            "item_code": "ITEM-001",
+            "qty": 5,
+        })
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_missing_items_in_slip(self):
+        packing_slips = [{"items": []}]
+        errors = validate_packing_slips(packing_slips, "SO-001")
+        self.assertTrue(any("no items" in e.lower() for e in errors))
+
+    def test_missing_sales_order_item(self):
+        packing_slips = [{"items": [{"item_code": "ITEM-001", "quantity": 1}]}]
+        errors = validate_packing_slips(packing_slips, "SO-001")
+        self.assertTrue(any("sales_order_item" in e.lower() for e in errors))
+
+    def test_zero_quantity(self):
+        packing_slips = [{"items": [{
+            "item_code": "ITEM-001",
+            "quantity": 0,
+            "sales_order_item": "abc123",
+        }]}]
+        errors = validate_packing_slips(packing_slips, "SO-001")
+        self.assertTrue(any("quantity" in e.lower() for e in errors))
+
+    def test_negative_quantity(self):
+        packing_slips = [{"items": [{
+            "item_code": "ITEM-001",
+            "quantity": -1,
+            "sales_order_item": "abc123",
+        }]}]
+        errors = validate_packing_slips(packing_slips, "SO-001")
+        self.assertTrue(any("quantity" in e.lower() for e in errors))
+
+    def test_so_item_not_found(self):
+        self.mock_frappe.db.get_value.return_value = None
+        packing_slips = [{"items": [{
+            "item_code": "ITEM-001",
+            "quantity": 1,
+            "sales_order_item": "missing_id",
+        }]}]
+        errors = validate_packing_slips(packing_slips, "SO-001")
+        self.assertTrue(any("does not exist" in e.lower() for e in errors))
+
+    def test_item_code_mismatch(self):
+        self.mock_frappe.db.get_value.return_value = frappe._dict({
+            "item_code": "DIFFERENT-ITEM",
+            "qty": 5,
+        })
+        packing_slips = [{"items": [{
+            "item_code": "ITEM-001",
+            "quantity": 1,
+            "sales_order_item": "abc123",
+        }]}]
+        errors = validate_packing_slips(packing_slips, "SO-001")
+        self.assertTrue(any("mismatch" in e.lower() for e in errors))
+
+    def test_quantity_exceeds_ordered(self):
+        self.mock_frappe.db.get_value.return_value = frappe._dict({
+            "item_code": "ITEM-001",
+            "qty": 2,
+        })
+        packing_slips = [{"items": [{
+            "item_code": "ITEM-001",
+            "quantity": 10,
+            "sales_order_item": "abc123",
+        }]}]
+        errors = validate_packing_slips(packing_slips, "SO-001")
+        self.assertTrue(any("exceeds" in e.lower() for e in errors))
+
+    def test_valid_packing_slip(self):
+        packing_slips = [{"items": [{
+            "item_code": "ITEM-001",
+            "quantity": 2,
+            "sales_order_item": "abc123",
+        }]}]
+        errors = validate_packing_slips(packing_slips, "SO-001")
+        self.assertEqual(errors, [])
+
+
+class TestPackOrderValidation(unittest.TestCase):
+    """Unit tests for pack_order input validation (no DB)."""
+
+    def _call_with_form_dict(self, data):
+        with patch("metactical.custom_scripts.utils.pps_api.frappe") as mock_frappe:
+            mock_frappe.form_dict = data
+            mock_frappe._dict = frappe._dict
+            # Re-import the function so it picks up the mock
+            from metactical.custom_scripts.utils import pps_api
+            with patch.object(pps_api, "frappe", mock_frappe):
+                return pps_api.pack_order()
+
+    def test_missing_order_id_returns_error(self):
+        result = self._call_with_form_dict({"packing_slips": []})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Order ID", result["message"])
+
+    def test_missing_packing_slips_returns_error(self):
+        result = self._call_with_form_dict({"order_id": "SAL-ORD-2026-00001"})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Packing slips", result["message"])
+
+    def test_empty_packing_slips_returns_error(self):
+        result = self._call_with_form_dict({
+            "order_id": "SAL-ORD-2026-00001",
+            "packing_slips": [],
+        })
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Packing slips", result["message"])
+
+
+class TestPackOrderIntegration(unittest.TestCase):
+    """
+    Integration tests for pack_order().
+
+    Real SO, Pick List, Delivery Note and Packing Slip documents are created.
+    Only call_pps_api_to_pack_order is mocked — it is an external service
+    placeholder and not part of the ERPNext document flow.
+
+    frappe.local.form_dict is set directly (the mechanism pack_order reads
+    through frappe.form_dict) so we call pack_order() with no extra wrapping.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        frappe.set_user("Administrator")
+        frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+        frappe.db.commit()
+
+    def _set_form_dict(self, order_id, packing_slips_payload):
+        frappe.local.form_dict = frappe._dict({
+            "order_id": order_id,
+            "packing_slips": packing_slips_payload,
+        })
+
+    def _pack(self, order_id, packing_slips_payload):
+        """Set form_dict and call pack_order(), mocking only the external PPS call."""
+        self._set_form_dict(order_id, packing_slips_payload)
+        with patch.object(pps_api, "call_pps_api_to_pack_order", return_value={"success": True}):
+            return pack_order()
+
+    # ------------------------------------------------------------------
+    # Happy-path: real documents must exist in DB after each call
+    # ------------------------------------------------------------------
+
+    def test_creates_pick_list_in_db(self):
+        so = make_test_sales_order()
+        payload = [{
+            "parcel_template": "BOX 1",
+            "dimensions": {"height": 10, "width": 9, "length": 5},
+            "weight": 2,
+            "items": [{
+                "item_code": so.items[0].item_code,
+                "quantity": int(so.items[0].qty),
+                "sales_order_item": so.items[0].name,
+            }],
+        }]
+
+        result = self._pack(so.name, payload)
+
+        self.assertEqual(result["status"], "success", result.get("message"))
+        self.assertTrue(
+            frappe.db.exists("Pick List", result["pick_list"]),
+            f"Pick List {result['pick_list']} not found in DB",
+        )
+
+    def test_creates_packing_slips_in_db(self):
+        so = make_test_sales_order()
+        payload = [{
+            "parcel_template": "BOX 1",
+            "dimensions": {"height": 10, "width": 9, "length": 5},
+            "weight"
+            "items": [{
+                "item_code": so.items[0].item_code,
+                "quantity": int(so.items[0].qty),
+                "sales_order_item": so.items[0].name,
+            }],
+        }]
+
+        result = self._pack(so.name, payload)
+
+        self.assertEqual(result["status"], "success", result.get("message"))
+        self.assertGreater(len(result["packing_slips"]), 0)
+        for ps_name in result["packing_slips"]:
+            self.assertTrue(
+                frappe.db.exists("Packing Slip", ps_name),
+                f"Packing Slip {ps_name} not found in DB",
+            )
+
+    def test_two_boxes_creates_two_packing_slips(self):
+        """Mirrors the example payload from the spec (two boxes, two items)."""
+        so = make_test_sales_order(item_list=[
+            {"item_code": "RFIWPG130-1", "warehouse": "R01-Gor-Active Stock - ICL", "qty": 1, "rate": 50},
+            {"item_code": "GS101799-6",  "warehouse": "R01-Gor-Active Stock - ICL", "qty": 1, "rate": 75},
+        ])
+
+        payload = [
+            {
+                "parcel_template": "BOX 1",
+                "dimensions": {"height": 10, "width": 9, "length": 5},
+                "weight": 2,
+                "items": [{"item_code": so.items[0].item_code, "quantity": 1, "sales_order_item": so.items[0].name}],
+            },
+            {
+                "parcel_template": "BOX 1",
+                "dimensions": {"height": 12, "width": 8, "length": 6},
+                "weight": 3,
+                "items": [{"item_code": so.items[1].item_code, "quantity": 1, "sales_order_item": so.items[1].name}],
+            },
+        ]
+
+        result = self._pack(so.name, payload)
+
+        self.assertEqual(result["status"], "success", result.get("message"))
+        self.assertTrue(frappe.db.exists("Pick List", result["pick_list"]))
+        self.assertEqual(len(result["packing_slips"]), 2)
+        for ps_name in result["packing_slips"]:
+            self.assertTrue(frappe.db.exists("Packing Slip", ps_name))
+
+    def test_packing_slip_dimensions_saved(self):
+        """Verify height/width/length/weight are persisted on the Packing Slip doc."""
+        so = make_test_sales_order()
+        payload = [{
+            "parcel_template": "BOX 1",
+            "dimensions": {"height": 15, "width": 11, "length": 8},
+            "weight": 4,
+            "items": [{
+                "item_code": so.items[0].item_code,
+                "quantity": int(so.items[0].qty),
+                "sales_order_item": so.items[0].name,
+            }],
+        }]
+
+        result = self._pack(so.name, payload)
+
+        self.assertEqual(result["status"], "success", result.get("message"))
+        ps = frappe.get_doc("Packing Slip", result["packing_slips"][0])
+        self.assertEqual(ps.custom_neb_box_height, 15)
+        self.assertEqual(ps.custom_neb_box_width, 11)
+        self.assertEqual(ps.custom_neb_box_length, 8)
+        self.assertEqual(ps.gross_weight_pkg, 4)
+
+    # ------------------------------------------------------------------
+    # Error-path: failures are injected via mocks, form_dict set directly
+    # ------------------------------------------------------------------
+
+    def test_pick_list_failure_propagates(self):
+        so = make_test_sales_order()
+        self._set_form_dict(so.name, [{
+            "parcel_template": "BOX 1",
+            "dimensions": {"height": 10, "width": 9, "length": 5},
+            "weight": 2,
+            "items": [{"item_code": so.items[0].item_code, "quantity": int(so.items[0].qty), "sales_order_item": so.items[0].name}],
+        }])
+
+        with patch.object(pps_api, "create_pick_list_for_order",
+                          return_value={"success": False, "error": "No stock available"}):
+            result = pack_order()
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("No stock available", result["message"])
+
+    def test_pps_api_failure_propagates(self):
+        so = make_test_sales_order()
+        self._set_form_dict(so.name, [{
+            "parcel_template": "BOX 1",
+            "dimensions": {"height": 10, "width": 9, "length": 5},
+            "weight": 2,
+            "items": [{"item_code": so.items[0].item_code, "quantity": int(so.items[0].qty), "sales_order_item": so.items[0].name}],
+        }])
+
+        with patch.object(pps_api, "create_pick_list_for_order",
+                          return_value={"success": True, "pick_list": "PL-DUMMY"}), \
+             patch.object(pps_api, "create_packing_slips", return_value=["PS-DUMMY"]), \
+             patch.object(pps_api.frappe, "get_doc", return_value=MagicMock(name="PL-DUMMY")), \
+             patch.object(pps_api, "call_pps_api_to_pack_order",
+                          return_value={"success": False, "error": "PPS service unavailable"}):
+            result = pack_order()
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("PPS service unavailable", result["message"])
+
+    def test_invalid_so_item_in_payload(self):
+        so = make_test_sales_order()
+        self._set_form_dict(so.name, [{
+            "parcel_template": "BOX 1",
+            "dimensions": {"height": 10, "width": 9, "length": 5},
+            "weight": 2,
+            "items": [{"item_code": so.items[0].item_code, "quantity": 1, "sales_order_item": "nonexistent_row_id"}],
+        }])
+
+        result = pack_order()
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("does not exist", result["message"])

--- a/metactical/metactical/doctype/pps_api_log/pps_api_log.js
+++ b/metactical/metactical/doctype/pps_api_log/pps_api_log.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, Storebuilder Commerce Inc and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("PPS API Log", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/metactical/metactical/doctype/pps_api_log/pps_api_log.json
+++ b/metactical/metactical/doctype/pps_api_log/pps_api_log.json
@@ -8,6 +8,7 @@
  "engine": "InnoDB",
  "field_order": [
   "payload",
+  "response",
   "request_type",
   "error",
   "sales_order",
@@ -63,12 +64,18 @@
    "fieldtype": "Data",
    "label": "Packing Slips",
    "read_only": 1
+  },
+  {
+   "fieldname": "response",
+   "fieldtype": "Text",
+   "label": "Response",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-25 12:53:07.367988",
+ "modified": "2026-05-26 12:46:59.964834",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "PPS API Log",

--- a/metactical/metactical/doctype/pps_api_log/pps_api_log.json
+++ b/metactical/metactical/doctype/pps_api_log/pps_api_log.json
@@ -1,0 +1,94 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-05-25 12:36:16.649989",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "payload",
+  "request_type",
+  "error",
+  "sales_order",
+  "delivery_note",
+  "pick_list",
+  "packing_slips"
+ ],
+ "fields": [
+  {
+   "fieldname": "payload",
+   "fieldtype": "Text",
+   "label": "Payload",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "request_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Request Type",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "error",
+   "fieldtype": "Text",
+   "label": "Error",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sales_order",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Sales Order",
+   "read_only": 1
+  },
+  {
+   "fieldname": "delivery_note",
+   "fieldtype": "Data",
+   "label": "Delivery Note",
+   "read_only": 1
+  },
+  {
+   "fieldname": "pick_list",
+   "fieldtype": "Data",
+   "label": "Pick List",
+   "read_only": 1
+  },
+  {
+   "fieldname": "packing_slips",
+   "fieldtype": "Data",
+   "label": "Packing Slips",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-05-25 12:53:07.367988",
+ "modified_by": "Administrator",
+ "module": "Metactical",
+ "name": "PPS API Log",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/metactical/metactical/doctype/pps_api_log/pps_api_log.py
+++ b/metactical/metactical/doctype/pps_api_log/pps_api_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Storebuilder Commerce Inc and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PPSAPILog(Document):
+	pass

--- a/metactical/metactical/doctype/pps_api_log/test_pps_api_log.py
+++ b/metactical/metactical/doctype/pps_api_log/test_pps_api_log.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Storebuilder Commerce Inc and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestPPSAPILog(FrappeTestCase):
+	pass


### PR DESCRIPTION
This pull request introduces a new DocType, `PPS API Log`, for tracking API interactions with the PPS system, and adds comprehensive unit and integration tests for the PPS API utility functions. The changes improve both backend reliability (with robust test coverage) and ERPNext system observability (with the new log DocType).

**Key changes:**

### 1. PPS API Log DocType Implementation
* Added new DocType `PPS API Log` with fields for payload, response, request type, error, sales order, delivery note, pick list, and packing slips, including permissions and metadata for ERPNext integration. (`pps_api_log.json`)
* Implemented the Python class `PPSAPILog` for the new DocType. (`pps_api_log.py`)
* Added a placeholder JavaScript file for client-side scripting of the DocType. (`pps_api_log.js`)
* Added a basic test class for the new DocType. (`test_pps_api_log.py`)

### 2. PPS API Utilities Test Coverage
* Added extensive unit and integration tests for `pack_order`, `flatten_packing_slip_items`, and `validate_packing_slips` in `test_pps_api.py`. These tests cover:
  - Input validation and error handling
  - Packing slip and pick list creation flows
  - Mocking of external API calls and database interactions
  - Real document creation and persistence checks in the ERPNext database