### PR TITLE
Fix: post item price import errors to rocket chat

### DIFF
--- a/metactical/custom_scripts/frappe/document.py
+++ b/metactical/custom_scripts/frappe/document.py
@@ -12,12 +12,11 @@ def execute_action(doctype, name, action, **kwargs):
 	try:
 		frappe.db.set_value(doctype, name, "ais_queue_status", "Not Queued", update_modified=False)
 		getattr(doc, action)(**kwargs)
-	except Exception:
+	except Exception as e:
 		frappe.db.rollback()
-
 		# add a comment (?)
 		if frappe.local.message_log:
-			msg = json.loads(frappe.local.message_log[-1]).get('message')
+			msg = str(e)
 		else:
 			msg = '<pre><code>' + frappe.get_traceback() + '</pre></code>'
 

--- a/metactical/custom_scripts/utils/metactical_utils.py
+++ b/metactical/custom_scripts/utils/metactical_utils.py
@@ -113,7 +113,7 @@ def post_to_rocket_chat(doc, msg, failed=False, rmq=False, pos=False, attachment
 			if response.status_code == 200:
 				pass
 			else:
-				frappe.log_error(title='Rocket Chat Error', message=response.json())
+				frappe.log_error(title='Rocket Chat Error', message=response.text)
 
 	except Exception as e:
 		frappe.log_error(title='Rocket Chat Error', message=frappe.get_traceback())

--- a/metactical/metactical/doctype/item_price_from_excel/item_price_from_excel.py
+++ b/metactical/metactical/doctype/item_price_from_excel/item_price_from_excel.py
@@ -125,14 +125,16 @@ class ItemPriceFromExcel(Document):
 						if price:
 							doc.save()
 					except Exception as e:
-						frappe.log_error(frappe.get_traceback())
-						error_log = frappe.new_doc("Item Price From Excel Error")
-						error_log.update({
-							"error": e,
-							"item_code": item_code,
-							"rate": price,
-							"parenttype": self.doctype,
-							"parent": self.name,
-							"parentfield": "error_log"
-						})
-						error_log.insert()
+						frappe.clear_last_message()
+						frappe.throw(str(e))
+						# frappe.log_error(frappe.get_traceback())
+						# error_log = frappe.new_doc("Item Price From Excel Error")
+						# error_log.update({
+						# 	"error": e,
+						# 	"item_code": item_code,
+						# 	"rate": price,
+						# 	"parenttype": self.doctype,
+						# 	"parent": self.name,
+						# 	"parentfield": "error_log"
+						# })
+						# error_log.insert()


### PR DESCRIPTION
This pull request focuses on improving error handling and logging across several modules. The main changes include making error messages more informative, updating how errors are logged, and simplifying error management in the price entry creation process.

**Error handling and logging improvements:**

* Changed exception handling in `execute_action` (in `document.py`) to log the actual exception message instead of parsing the last message log, providing clearer and more direct error information.
* Updated error logging in `post_to_rocket_chat` (in `metactical_utils.py`) to use the raw response text instead of attempting to parse JSON, making logs more robust to unexpected response formats.

**Price entry creation process:**

* Modified error handling in `create_price_entries` (in `item_price_from_excel.py`) to immediately throw the exception message and clear the last message, while commenting out the previous logic that created a custom error log document. This simplifies the process and ensures errors are surfaced directly.