### PR TITLE
fix: enhance RabbitMQ connection handling and ensure proper closure

### DIFF
--- a/metactical/custom_scripts/utils/rabbitmq_handler.py
+++ b/metactical/custom_scripts/utils/rabbitmq_handler.py
@@ -3,9 +3,17 @@ import pika
 import json
 
 def publish_to_rabbitmq(server_ip, exchange, exchange_type, routing_key, message, username, password, queue_name):
+    connection = None
     try:
         credentials = pika.PlainCredentials(username, password)
-        parameters = pika.ConnectionParameters(host=server_ip, credentials=credentials)
+        parameters = pika.ConnectionParameters(
+            host=server_ip,
+            credentials=credentials,
+            connection_attempts=2,
+            retry_delay=1,
+            socket_timeout=10,
+            blocked_connection_timeout=10,
+        )
         connection = pika.BlockingConnection(parameters)
         channel = connection.channel()
         
@@ -25,16 +33,20 @@ def publish_to_rabbitmq(server_ip, exchange, exchange_type, routing_key, message
         channel.basic_publish(
             exchange=exchange,
             routing_key=routing_key,
-            body=json.dumps(message),  # Convert message dictionary to JSON string
+            body=json.dumps(message),
             properties=pika.BasicProperties(
                 delivery_mode=2,  # Make message persistent
             ))
         frappe.logger().info(f"RabbitMQProxy: Message published to exchange: {exchange} (routing key: {routing_key})")
-        
-        connection.close()
     except Exception as e:
         frappe.logger().error(f"RabbitMQProxy: Error publishing message: {str(e)}")
         raise e
+    finally:
+        if connection is not None and not connection.is_closed:
+            try:
+                connection.close()
+            except BaseException:
+                pass
 
 @frappe.whitelist(allow_guest=True)
 def webhook():


### PR DESCRIPTION
This pull request improves the reliability and safety of the `publish_to_rabbitmq` function in `rabbitmq_handler.py` by enhancing connection handling and ensuring proper resource cleanup. The main changes focus on making the RabbitMQ connection more robust and preventing resource leaks.

Connection handling improvements:

* Added connection parameters such as `connection_attempts`, `retry_delay`, `socket_timeout`, and `blocked_connection_timeout` to the `pika.ConnectionParameters` configuration for more robust and resilient RabbitMQ connections.

Resource cleanup and error handling:

* Moved the connection close logic into a `finally` block to ensure the RabbitMQ connection is always closed, even if an exception occurs, and added a safety check to avoid errors if the connection is already closed.