### PR TITLE
chore: added retail sku in bulk update rule doctype

### DIFF
--- a/metactical/metactical/doctype/bulk_update_rule/bulk_update_rule.json
+++ b/metactical/metactical/doctype/bulk_update_rule/bulk_update_rule.json
@@ -121,11 +121,12 @@
   {
    "fieldname": "updated_retail_skus",
    "fieldtype": "Long Text",
-   "label": "Updated Retail SKUs"
+   "label": "Updated Retail SKUs",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2026-06-12 06:52:38.463180",
+ "modified": "2026-06-12 07:05:15.371830",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Bulk Update Rule",

--- a/metactical/metactical/doctype/bulk_update_rule/bulk_update_rule.json
+++ b/metactical/metactical/doctype/bulk_update_rule/bulk_update_rule.json
@@ -1,149 +1,156 @@
 {
-    "actions": [],
-    "allow_rename": 1,
-    "autoname": "field:rule_name",
-    "creation": "2025-01-01 00:00:00.000000",
-    "doctype": "DocType",
-    "engine": "InnoDB",
-    "field_order": [
-      "rule_name",
-      "description",
-      "target_doctype",
-      "section_conditions",
-      "conditions",
-      "section_actions",
-      "actions",
-      "section_execution",
-      "last_executed_on",
-      "column_break_exec",
-      "last_executed_by",
-      "last_match_count",
-      "execution_status",
-      "execution_log",
-      "updated_items"
-    ],
-    "fields": [
-      {
-        "fieldname": "rule_name",
-        "fieldtype": "Data",
-        "label": "Rule Name",
-        "reqd": 1,
-        "unique": 1
-      },
-      {
-        "fieldname": "description",
-        "fieldtype": "Small Text",
-        "label": "Description"
-      },
-      {
-        "default": "Item",
-        "fieldname": "target_doctype",
-        "fieldtype": "Link",
-        "label": "Target DocType",
-        "options": "DocType",
-        "reqd": 1
-      },
-      {
-        "fieldname": "section_conditions",
-        "fieldtype": "Section Break",
-        "label": "Search Conditions"
-      },
-      {
-        "fieldname": "conditions",
-        "fieldtype": "Table",
-        "label": "Conditions",
-        "options": "Bulk Update Condition",
-        "reqd": 1
-      },
-      {
-        "fieldname": "section_actions",
-        "fieldtype": "Section Break",
-        "label": "Actions"
-      },
-      {
-        "fieldname": "actions",
-        "fieldtype": "Table",
-        "label": "Actions",
-        "options": "Bulk Update Action",
-        "reqd": 1
-      },
-      {
-        "fieldname": "section_execution",
-        "fieldtype": "Section Break",
-        "label": "Execution History"
-      },
-      {
-        "fieldname": "last_executed_on",
-        "fieldtype": "Datetime",
-        "label": "Last Executed On",
-        "read_only": 1
-      },
-      {
-        "fieldname": "column_break_exec",
-        "fieldtype": "Column Break"
-      },
-      {
-        "fieldname": "last_executed_by",
-        "fieldtype": "Link",
-        "label": "Last Executed By",
-        "options": "User",
-        "read_only": 1
-      },
-      {
-        "fieldname": "last_match_count",
-        "fieldtype": "Int",
-        "label": "Last Match Count",
-        "read_only": 1
-      },
-      {
-        "fieldname": "execution_status",
-        "fieldtype": "Select",
-        "label": "Execution Status",
-        "options": "\nQueued\nRunning\nCompleted\nFailed",
-        "read_only": 1
-      },
-      {
-        "fieldname": "execution_log",
-        "fieldtype": "Long Text",
-        "label": "Execution Log",
-        "read_only": 1
-      },
-      {
-        "fieldname": "updated_items",
-        "fieldtype": "Long Text",
-        "label": "Updated Items",
-        "read_only": 1,
-        "description": "Comma-separated list of item names updated in the last execution"
-      }
-    ],
-    "index_web_pages_for_search": 0,
-    "links": [],
-    "modified": "2025-01-01 00:00:00.000000",
-    "modified_by": "Administrator",
-    "module": "Metactical",
-    "name": "Bulk Update Rule",
-    "naming_rule": "By fieldname",
-    "owner": "Administrator",
-    "permissions": [
-      {
-        "create": 1,
-        "delete": 1,
-        "read": 1,
-        "role": "System Manager",
-        "write": 1
-      },
-      {
-        "create": 1,
-        "delete": 0,
-        "read": 1,
-        "role": "Item Manager",
-        "write": 1
-      }
-    ],
-    "search_fields": "rule_name,description",
-    "sort_field": "modified",
-    "sort_order": "DESC",
-    "states": [],
-    "title_field": "rule_name",
-    "track_changes": 1
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:rule_name",
+ "creation": "2025-01-01 00:00:00",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "rule_name",
+  "description",
+  "target_doctype",
+  "section_conditions",
+  "conditions",
+  "section_actions",
+  "actions",
+  "section_execution",
+  "last_executed_by",
+  "last_executed_on",
+  "execution_status",
+  "last_match_count",
+  "column_break_exec",
+  "execution_log",
+  "updated_items",
+  "updated_retail_skus"
+ ],
+ "fields": [
+  {
+   "fieldname": "rule_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Rule Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "default": "Item",
+   "fieldname": "target_doctype",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Target DocType",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_conditions",
+   "fieldtype": "Section Break",
+   "label": "Search Conditions"
+  },
+  {
+   "fieldname": "conditions",
+   "fieldtype": "Table",
+   "label": "Conditions",
+   "options": "Bulk Update Condition",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_actions",
+   "fieldtype": "Section Break",
+   "label": "Actions"
+  },
+  {
+   "fieldname": "actions",
+   "fieldtype": "Table",
+   "label": "Actions",
+   "options": "Bulk Update Action",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_execution",
+   "fieldtype": "Section Break",
+   "label": "Execution History"
+  },
+  {
+   "fieldname": "last_executed_on",
+   "fieldtype": "Datetime",
+   "label": "Last Executed On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_exec",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "last_executed_by",
+   "fieldtype": "Link",
+   "label": "Last Executed By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_match_count",
+   "fieldtype": "Int",
+   "label": "Last Match Count",
+   "read_only": 1
+  },
+  {
+   "fieldname": "execution_status",
+   "fieldtype": "Select",
+   "label": "Execution Status",
+   "options": "\nQueued\nRunning\nCompleted\nFailed",
+   "read_only": 1
+  },
+  {
+   "fieldname": "execution_log",
+   "fieldtype": "Long Text",
+   "label": "Execution Log",
+   "read_only": 1
+  },
+  {
+   "description": "Comma-separated list of item names updated in the last execution",
+   "fieldname": "updated_items",
+   "fieldtype": "Long Text",
+   "label": "Updated Items",
+   "read_only": 1
+  },
+  {
+   "fieldname": "updated_retail_skus",
+   "fieldtype": "Long Text",
+   "label": "Updated Retail SKUs"
   }
+ ],
+ "links": [],
+ "modified": "2026-06-12 06:52:38.463180",
+ "modified_by": "Administrator",
+ "module": "Metactical",
+ "name": "Bulk Update Rule",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "role": "Item Manager",
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "search_fields": "rule_name,description",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "rule_name",
+ "track_changes": 1
+}

--- a/metactical/metactical/doctype/bulk_update_rule/bulk_update_rule.py
+++ b/metactical/metactical/doctype/bulk_update_rule/bulk_update_rule.py
@@ -537,6 +537,18 @@ def run_bulk_update(rule_name):
             log_lines.append(f"Errors ({len(errors)}):")
             log_lines.extend(errors[:50])
 
+        retail_skus = []
+        if updated_item_ids:
+            sku_map = {
+                r.name: r.ifw_retailskusuffix
+                for r in frappe.get_all(
+                    "Item",
+                    filters={"name": ["in", updated_item_ids]},
+                    fields=["name", "ifw_retailskusuffix"],
+                )
+            }
+            retail_skus = [sku_map.get(n) or "" for n in updated_item_ids]
+
         doc.reload()
         doc.execution_status = "Completed"
         doc.last_executed_on = now_datetime()
@@ -544,6 +556,7 @@ def run_bulk_update(rule_name):
         doc.last_match_count = total
         doc.execution_log = "\n".join(log_lines)
         doc.updated_items = ",".join(updated_item_ids)
+        doc.updated_retail_skus = ",".join(retail_skus)
         doc.save(ignore_permissions=True)
         frappe.db.commit()
 


### PR DESCRIPTION
This pull request updates the `Bulk Update Rule` DocType and its execution logic to improve tracking of updated items and their associated retail SKUs. It introduces a new read-only field for storing updated retail SKUs, ensures these are populated after each bulk update, and makes minor usability improvements to the DocType configuration.

**DocType enhancements:**

* Added a new read-only field `updated_retail_skus` of type `Long Text` to store a comma-separated list of retail SKU suffixes for items updated in the last execution. [[1]](diffhunk://#diff-3261c586fe88fed324100caf13af6ad508023b0f88fab39acdc05b46ad3e4198L17-R30) [[2]](diffhunk://#diff-3261c586fe88fed324100caf13af6ad508023b0f88fab39acdc05b46ad3e4198R115-R129)
* Improved field ordering and added `in_list_view` property to `rule_name` and `target_doctype` fields for better visibility in list views. [[1]](diffhunk://#diff-3261c586fe88fed324100caf13af6ad508023b0f88fab39acdc05b46ad3e4198L17-R30) [[2]](diffhunk://#diff-3261c586fe88fed324100caf13af6ad508023b0f88fab39acdc05b46ad3e4198R44)
* Set `row_format` to `Dynamic` for the DocType for improved table handling.

**Bulk update execution logic:**

* Updated the `run_bulk_update` function to collect and store the corresponding retail SKU suffixes for each updated item in the new `updated_retail_skus` field after execution.

**Other minor changes:**

* Standardized the datetime format for `creation` and `modified` fields in the DocType JSON. [[1]](diffhunk://#diff-3261c586fe88fed324100caf13af6ad508023b0f88fab39acdc05b46ad3e4198L5-R5) [[2]](diffhunk://#diff-3261c586fe88fed324100caf13af6ad508023b0f88fab39acdc05b46ad3e4198R115-R129)