### PR TITLE
S3 uploader: template-keyed records, legacy migration, and per-order image sets

### DIFF
--- a/metactical/metactical/doctype/s3_product_image_meta_data/s3_product_image_meta_data.json
+++ b/metactical/metactical/doctype/s3_product_image_meta_data/s3_product_image_meta_data.json
@@ -6,27 +6,16 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_3fll",
-  "amended_from",
   "nat_override_full_product",
+  "nat_product_template",
   "nat_skus",
   "nat_sites",
-  "nat_images",
-  "nat_uploaded_by"
+  "nat_images"
  ],
  "fields": [
   {
    "fieldname": "section_break_3fll",
    "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "amended_from",
-   "fieldtype": "Link",
-   "label": "Amended From",
-   "no_copy": 1,
-   "options": "S3 Product Image Meta Data",
-   "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
   },
   {
    "default": "0",
@@ -57,18 +46,17 @@
    "reqd": 1
   },
   {
-   "fieldname": "nat_uploaded_by",
+   "fieldname": "nat_product_template",
    "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Uploaded By",
-   "options": "User"
+   "label": "Product Template",
+   "options": "Item",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
- "is_submittable": 1,
  "links": [],
- "modified": "2026-06-03 14:22:37.314673",
+ "modified": "2026-06-17 07:20:12.365804",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "S3 Product Image Meta Data",

--- a/metactical/metactical/doctype/s3_product_image_meta_data/s3_product_image_meta_data.py
+++ b/metactical/metactical/doctype/s3_product_image_meta_data/s3_product_image_meta_data.py
@@ -4,7 +4,9 @@
 import frappe
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
-from frappe.utils import cint, now_datetime
+from frappe.utils import cint
+
+ROLES = ("icon", "small", "medium", "large")
 
 
 class S3ProductImageMetaData(Document):
@@ -12,41 +14,124 @@ class S3ProductImageMetaData(Document):
 
 
 def _build_record_name(template_item):
-	"""Readable record name: "<template item code> <timestamp>".
+	"""Name the record after its product template (one record per template).
 
-	e.g. "UMX225245-01 jun 16 2026 8:09:12". A numeric suffix is appended if a
-	record with the same name already exists (two uploads in the same second).
+	A numeric suffix is appended only if that exact name somehow already exists.
 	"""
-	dt = now_datetime()
-	stamp = f"{dt.strftime('%b')} {dt.day} {dt.year} {dt.hour}:{dt.minute:02d}:{dt.second:02d}"
-	base = f"{template_item} {stamp}" if template_item else stamp
-	return append_number_if_name_exists("S3 Product Image Meta Data", base)
-	
+	return append_number_if_name_exists("S3 Product Image Meta Data", template_item)
 
-def upsert_upload(files, override_full_product=0, template_item=None):
-	"""Create ONE submitted record for an upload from its per-FILE records.
 
-	`files` is one entry per uploaded image::
+def _new_state(files):
+	"""Comparable snapshot of an upload payload.
 
-	    [{ "role", "order", "path", "skuItems": [{item_code, sku}], "sites": [...] }]
+	`images` is keyed per image (sku, order, role) and carries both the path and the
+	image's own set of websites, so per-image site/order changes are detectable.
+	"""
+	skus = {}  # sku -> item_code
+	images = {}  # (sku, order, role) -> {"path", "sites": frozenset}
+	for f in files:
+		role = f["role"]
+		order = f.get("order") or 0
+		path = f.get("path")
+		fsites = frozenset(f.get("sites") or [])
+		for item in f["skuItems"]:
+			sku = item.get("sku")
+			if not sku:
+				continue
+			skus.setdefault(sku, item.get("item_code"))
+			if path:
+				images[(sku, order, role)] = {"path": path, "sites": fsites}
+	return {"skus": skus, "images": images}
+
+
+def _doc_state(doc):
+	"""Comparable snapshot of a stored record (same shape as `_new_state`)."""
+	skus = {r.nat_sku: r.nat_item_code for r in doc.nat_skus if r.nat_sku}
+
+	# Sites tagged per image: (sku, order, role) -> set of websites.
+	sites_by = {}
+	for r in doc.nat_sites:
+		key = (r.nat_sku, r.nat_image_order or 0, r.nat_role)
+		sites_by.setdefault(key, set()).add(r.nat_site)
+
+	images = {}
+	for r in doc.nat_images:
+		for role in ROLES:
+			path = r.get("nat_" + role)
+			if path:
+				key = (r.nat_sku, r.nat_image_order or 0, role)
+				images[key] = {"path": path, "sites": frozenset(sites_by.get(key, set()))}
+	return {"skus": skus, "images": images}
+
+
+def _fmt_img(key, item_of):
+	"""Readable label for one image: "icon of UMX225245-01 (order 1)" (item code)."""
+	sku, order, role = key
+	code = item_of.get(sku) or sku
+	return f"{role} of {code} (order {order})"
+
+
+def _change_summary(old, new, old_override=None, new_override=None):
+	"""Specific, human-readable list of what changed between two snapshots."""
+	lines = []
+
+	# sku -> item code, so the log shows item codes rather than retail SKUs.
+	item_of = {**old["skus"], **new["skus"]}
+
+	if old_override is not None and old_override != new_override:
+		lines.append(f"Override Full Product: turned {'ON' if new_override else 'OFF'}")
+
+	old_skus, new_skus = set(old["skus"]), set(new["skus"])
+	added_codes = sorted({item_of.get(s) or s for s in new_skus - old_skus})
+	removed_codes = sorted({item_of.get(s) or s for s in old_skus - new_skus})
+	if added_codes or removed_codes:
+		parts = []
+		if added_codes:
+			parts.append(f"added {', '.join(added_codes)}")
+		if removed_codes:
+			parts.append(f"removed {', '.join(removed_codes)}")
+		lines.append(f"Items: {'; '.join(parts)}")
+
+	oi, ni = old["images"], new["images"]
+	added = sorted(k for k in ni if k not in oi)
+	removed = sorted(k for k in oi if k not in ni)
+	if added:
+		lines.append("Images added: " + ", ".join(_fmt_img(k, item_of) for k in added))
+	if removed:
+		lines.append("Images removed: " + ", ".join(_fmt_img(k, item_of) for k in removed))
+
+	# Images present in both: detect replaced files and per-image website changes.
+	for k in sorted(set(oi) & set(ni)):
+		o, n = oi[k], ni[k]
+		if o["path"] != n["path"]:
+			lines.append(f"Image replaced: {_fmt_img(k, item_of)}")
+		if o["sites"] != n["sites"]:
+			s_add = sorted(n["sites"] - o["sites"])
+			s_rem = sorted(o["sites"] - n["sites"])
+			parts = []
+			if s_add:
+				parts.append(f"added {', '.join(s_add)}")
+			if s_rem:
+				parts.append(f"removed {', '.join(s_rem)}")
+			lines.append(f"Websites on {_fmt_img(k, item_of)}: {'; '.join(parts)}")
+
+	return lines
+
+
+def _populate(doc, files, override_full_product, template_item):
+	"""(Re)build the child tables of `doc` from the per-FILE upload payload.
 
 	SKUs go to `nat_skus`; images are grouped by (sku, order) into `nat_images`
-	(role columns); and each site is stored tagged with its image's SKU + order +
-	role on `nat_sites`, so sites can be restored per image (not unioned).
-
-	The record is named "<template_item> <timestamp>" for readability.
+	(role columns); each site is stored tagged with its image's SKU + order + role
+	on `nat_sites`, so sites can be restored per image (not unioned).
 	"""
-	files = [f for f in files if f.get("role") and (f.get("skuItems") or [])]
-	if not files:
-		return None
-
-	doc = frappe.new_doc("S3 Product Image Meta Data")
 	doc.nat_override_full_product = 1 if cint(override_full_product) else 0
-	doc.nat_uploaded_by = frappe.session.user
+	if template_item:
+		doc.nat_product_template = template_item
 
-	# Give the record a human-readable name instead of a random hash.
-	doc.name = _build_record_name(template_item)
-	doc.flags.name_set = True
+	doc.set("nat_skus", [])
+	doc.set("nat_sites", [])
+	doc.set("nat_images", [])
 
 	seen_skus = {}
 	image_rows = {}  # (sku, order) -> nat_images row
@@ -78,6 +163,67 @@ def upsert_upload(files, override_full_product=0, template_item=None):
 					{"nat_site": site, "nat_sku": sku, "nat_image_order": order, "nat_role": role},
 				)
 
-	doc.insert(ignore_permissions=True)
-	doc.submit()
+
+def upsert_upload(files, override_full_product=0, template_item=None):
+	"""Upsert one record per product template from the per-FILE upload payload.
+
+	If a record already exists for `template_item` it is updated in place and a
+	timeline comment logs what changed (SKUs / websites / images added or removed);
+	otherwise a new record named "<template> <timestamp>" is created.
+	"""
+	files = [f for f in files if f.get("role") and (f.get("skuItems") or [])]
+	if not files:
+		return None
+
+	new_state = _new_state(files)
+
+	existing = None
+	if template_item:
+		matches = frappe.get_all(
+			"S3 Product Image Meta Data",
+			filters={"nat_product_template": template_item},
+			order_by="creation desc",
+			limit=1,
+			pluck="name",
+		)
+		existing = matches[0] if matches else None
+
+	new_override = 1 if cint(override_full_product) else 0
+
+	if existing:
+		doc = frappe.get_doc("S3 Product Image Meta Data", existing)
+		# Normalize any legacy record that was submitted before this became editable.
+		if doc.docstatus == 1:
+			doc.docstatus = 0
+		old_state = _doc_state(doc)
+		old_override = 1 if cint(doc.nat_override_full_product) else 0
+		_populate(doc, files, override_full_product, template_item)
+		doc.save(ignore_permissions=True)
+
+		# Always log the save; spell out exactly what changed (incl. override).
+		lines = _change_summary(old_state, new_state, old_override, new_override)
+		if lines:
+			text = "Updated this product:<br>" + "<br>".join("• " + l for l in lines)
+		else:
+			text = "Saved with no changes."
+		doc.add_comment("Comment", text)
+	else:
+		doc = frappe.new_doc("S3 Product Image Meta Data")
+		doc.name = _build_record_name(template_item)
+		doc.flags.name_set = True
+		_populate(doc, files, override_full_product, template_item)
+		doc.insert(ignore_permissions=True)
+
+		items = ", ".join(sorted({(v or k) for k, v in new_state["skus"].items()})) or "—"
+		all_sites = sorted({s for img in new_state["images"].values() for s in img["sites"]})
+		sites = ", ".join(all_sites) or "—"
+		doc.add_comment(
+			"Comment",
+			"Created this product:<br>"
+			f"• Items: {items}<br>"
+			f"• Websites: {sites}<br>"
+			f"• Images: {len(new_state['images'])}<br>"
+			f"• Override Full Product: {'ON' if new_override else 'OFF'}",
+		)
+
 	return doc.name

--- a/metactical/metactical/page/s3_uploader/s3_uploader.py
+++ b/metactical/metactical/page/s3_uploader/s3_uploader.py
@@ -222,6 +222,21 @@ def get_item_family(item_code):
 
 
 @frappe.whitelist()
+def find_template_record(template_item):
+	"""Return the existing record for a product template, if any: {"name": ...} or {}."""
+	if not template_item:
+		return {}
+	rows = frappe.get_all(
+		"S3 Product Image Meta Data",
+		filters={"nat_product_template": template_item},
+		order_by="modified desc",
+		limit=1,
+		pluck="name",
+	)
+	return {"name": rows[0]} if rows else {}
+
+
+@frappe.whitelist()
 def get_s3_meta(key):
 	"""Fetch and parse a legacy metadata JSON file from S3. Returns {found, metadata}."""
 	settings = _get_settings()
@@ -252,8 +267,8 @@ def save_metadata(files, override_full_product=0, template_item=None):
 
 @frappe.whitelist()
 def list_metadata(filter=None):
-	"""List submitted S3 Product Image Meta Data records (optionally by SKU)."""
-	record_filters = {"docstatus": 1}
+	"""List S3 Product Image Meta Data records (optionally by SKU)."""
+	record_filters = {}
 	if filter:
 		# SKUs live on the child table now; find parents with a matching SKU.
 		parents = frappe.get_all(
@@ -407,12 +422,12 @@ def build_export_json(names=None):
 
 	Each record holds one upload, stored per-SKU. SKUs whose sites AND images are
 	identical are merged into one product (productsku lists all of them). Pass `names`
-	(a JSON list or single name) to limit records; otherwise all submitted records.
+	(a JSON list or single name) to limit records; otherwise all records.
 	"""
 	if isinstance(names, str):
 		names = json.loads(names) if names.strip().startswith("[") else [names]
 
-	filters = {"docstatus": 1}
+	filters = {}
 	if names:
 		filters["name"] = ["in", names]
 

--- a/metactical/metactical/page/s3_uploader/s3_uploader.py
+++ b/metactical/metactical/page/s3_uploader/s3_uploader.py
@@ -236,6 +236,77 @@ def find_template_record(template_item):
 	return {"name": rows[0]} if rows else {}
 
 
+def _meta_skus(meta):
+	"""All productsku values referenced by a legacy metadata JSON."""
+	found = set()
+	products = meta.get("products")
+	if isinstance(products, list):
+		for p in products:
+			ps = p.get("productsku")
+			if isinstance(ps, list):
+				found.update(x for x in ps if x)
+			elif ps:
+				found.add(ps)
+	elif isinstance(products, dict):
+		for p in products.values():
+			found.update(x for x in (p.get("skus") or []) if x)
+	return found
+
+
+@frappe.whitelist()
+def find_legacy_meta(skus):
+	"""Find the old system's metadata JSON for a product without scanning the folder.
+
+	Legacy meta files are named `<sku1>-<sku2>-..._metadata.json`, always starting with one
+	of the product's SKUs. So a prefix LIST per variant SKU narrows to a handful of candidates
+	server-side — fast on a bucket of any size — and each candidate is then content-confirmed
+	against the SKUs (handles SKUs that themselves contain "-"). Returns
+	{"found": True, "key", "name"} or {"found": False}.
+	"""
+	if isinstance(skus, str):
+		skus = json.loads(skus)
+	sku_set = {s for s in (skus or []) if s}
+	if not sku_set:
+		return {"found": False}
+
+	settings = _get_settings()
+	client = settings.get_client()
+	meta_prefix = f"{BASE_PREFIX}/meta/"
+
+	# Candidate keys via a SKU-prefixed LIST (server-side filtered, ~one call per SKU).
+	candidates = []
+	seen = set()
+	for sku in sku_set:
+		token = None
+		while True:
+			kwargs = {"Bucket": settings.nat_bucket_name, "Prefix": f"{meta_prefix}{sku}"}
+			if token:
+				kwargs["ContinuationToken"] = token
+			resp = client.list_objects_v2(**kwargs)
+			for obj in resp.get("Contents", []):
+				key = obj["Key"]
+				if key.endswith(".json") and key not in seen:
+					seen.add(key)
+					candidates.append(key)
+			if resp.get("IsTruncated"):
+				token = resp.get("NextContinuationToken")
+			else:
+				break
+
+	# Confirm by content — a prefix can over-match (e.g. "96670" vs "966700"), so the
+	# productsku list is the source of truth. Candidates are few, so this is cheap.
+	for key in candidates[:50]:
+		try:
+			body = client.get_object(Bucket=settings.nat_bucket_name, Key=key)["Body"].read()
+			meta = json.loads(body)
+		except Exception:
+			continue
+		if sku_set & _meta_skus(meta):
+			return {"found": True, "key": key, "name": key.split("/")[-1]}
+
+	return {"found": False}
+
+
 @frappe.whitelist()
 def get_s3_meta(key):
 	"""Fetch and parse a legacy metadata JSON file from S3. Returns {found, metadata}."""

--- a/metactical/public/js/components/s3_uploader/FileUploader.vue
+++ b/metactical/public/js/components/s3_uploader/FileUploader.vue
@@ -73,6 +73,24 @@
       </div>
     </div>
 
+    <!-- Image Orders (check to add a whole order's 4 sizes for every variant; uncheck to remove) -->
+    <div v-if="templateItem" class="border rounded-lg p-4 shadow-sm">
+      <label class="block text-sm font-bold mb-2">Image Orders</label>
+      <div class="flex flex-wrap gap-x-5 gap-y-2">
+        <label v-for="n in ORDER_OPTIONS" :key="n" class="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            :checked="existingOrders.has(n)"
+            @change="toggleOrder(n, $event.target.checked)"
+          />
+          Order {{ n }}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        </label>
+      </div>
+      <p class="text-xs text-gray-500 mt-2">
+        Check an order to add icon/small/medium/large slots for every variant; uncheck to remove that order.
+      </p>
+    </div>
+
     <!-- Stats bar -->
     <div v-if="files.length" class="bg-gray-50 border rounded-lg p-4">
       <div class="flex items-center justify-between text-sm text-gray-600">
@@ -684,35 +702,63 @@ const templateRef = ref(null)             // DOM node for the native Link contro
 let templateControl = null
 const ROLES = ['icon', 'small', 'medium', 'large']
 
-// Build one empty upload card per (variant × role): N variants → N×4 cards, each
-// pre-assigned to its variant's SKU. The user just drops the image into each.
-const scaffoldVariantCards = () => {
+// One empty placeholder card for a (variant, role, order) — awaiting an image upload.
+const buildVariantCard = (v, role, order) => ({
+  name: order ? `${v.sku}_${order}_${role}.jpg` : `${v.sku}_${role}.jpg`,
+  type: null,
+  file: null,
+  role,
+  width: 0,
+  height: 0,
+  skus: v.sku,
+  skuItems: [{ item_code: v.item_code, sku: v.sku }],
+  newItemCode: '',
+  skuError: '',
+  resolvingItem: false,
+  sites: [],
+  imageOrder: order,
+  preview: null,
+  isOnServer: false,
+  serverPath: null,
+  isModified: false,
+  isPlaceholder: true,
+})
+
+// Scaffold one image order: a card per (variant × role) at `order`.
+const scaffoldOrder = (order) => {
   const cards = []
   templateVariants.value.forEach(v => {
-    ROLES.forEach(role => {
-      cards.push({
-        name: `${v.sku}_${role}.jpg`,
-        type: null,
-        file: null,
-        role,
-        width: 0,
-        height: 0,
-        skus: v.sku,
-        skuItems: [{ item_code: v.item_code, sku: v.sku }],
-        newItemCode: '',
-        skuError: '',
-        resolvingItem: false,
-        sites: [],
-        imageOrder: 0,
-        preview: null,
-        isOnServer: false,
-        serverPath: null,
-        isModified: false,
-        isPlaceholder: true, // awaiting an image upload
-      })
-    })
+    ROLES.forEach(role => cards.push(buildVariantCard(v, role, order)))
   })
   files.value.push(...cards)
+}
+
+// Build the default (order 0) upload slots for every variant.
+const scaffoldVariantCards = () => scaffoldOrder(0)
+
+// Fixed image-order checkboxes (Order 0…Order 10). Display number = internal imageOrder.
+const ORDER_OPTIONS = Array.from({ length: 11 }, (_, n) => n)
+
+// Which orders currently have cards — drives the checked state of the boxes.
+const existingOrders = computed(() => new Set(files.value.map(f => f.imageOrder)))
+
+// Add an order's empty 4-size slots for every variant (no-op if it already exists).
+const addOrderSlots = (order) => {
+  if (existingOrders.value.has(order)) return
+  scaffoldOrder(order)
+}
+
+// Remove every card of an order (revoking previews) — drops it from the working set.
+const removeOrder = (order) => {
+  files.value.forEach(f => {
+    if (f.imageOrder === order && f.preview) URL.revokeObjectURL(f.preview)
+  })
+  files.value = files.value.filter(f => f.imageOrder !== order)
+}
+
+const toggleOrder = (order, checked) => {
+  if (checked) addOrderSlots(order)
+  else removeOrder(order)
 }
 
 // Clear the file cards (and upload history) without touching the chosen template.

--- a/metactical/public/js/components/s3_uploader/FileUploader.vue
+++ b/metactical/public/js/components/s3_uploader/FileUploader.vue
@@ -792,13 +792,127 @@ const applyTemplateFromItem = async (itemCode) => {
       s3LoadingProgress.value = { completed: 0, total: 0, current: '' }
     }
   } else if (templateVariants.value.length) {
-    scaffoldVariantCards()
-    frappe.show_alert({ message: `Created ${templateVariants.value.length * ROLES.length} upload slots (${templateVariants.value.length} variants × 4 sizes)`, indicator: 'blue' })
+    // No new-system record yet — check the OLD S3 system before scaffolding.
+    let legacy = null
+    try {
+      legacy = await callBackend('find_legacy_meta', { skus: JSON.stringify(templateVariants.value.map(v => v.sku)) })
+    } catch (e) {
+      console.error('Failed to check the old system:', e)
+    }
+    if (legacy && legacy.found) {
+      promptMigrateOrCreate(legacy.key)
+    } else {
+      scaffoldAndNotify()
+    }
   }
 
   // Reflect the resolved template back into the picker input.
   if (templateControl && templateItem.value && templateControl.get_value() !== templateItem.value) {
     templateControl.set_value(templateItem.value)
+  }
+}
+
+// Build the empty per-variant upload slots and announce it.
+const scaffoldAndNotify = () => {
+  resetFiles()
+  scaffoldVariantCards()
+  frappe.show_alert({ message: `Created ${templateVariants.value.length * ROLES.length} upload slots (${templateVariants.value.length} variants × 4 sizes)`, indicator: 'blue' })
+}
+
+// Small popup when old-system data exists: migrate it, or start fresh.
+const promptMigrateOrCreate = (metaKey) => {
+  const d = new frappe.ui.Dialog({
+    title: __('Found in old system'),
+    primary_action_label: __('Migrate'),
+    primary_action: () => { d.hide(); migrateFromLegacy(metaKey) },
+  })
+  d.$body.html(
+    `<div style="padding:6px 0 12px">This product already has data in the old S3 system. ` +
+    `Do you want to <b>migrate</b> that data, or <b>create a new</b> upload?</div>`
+  )
+  d.set_secondary_action_label(__('Create new'))
+  d.set_secondary_action(() => { d.hide(); scaffoldAndNotify() })
+  d.show()
+}
+
+// Migrate a product from the old system: load its legacy metadata JSON + images.
+const migrateFromLegacy = async (metaKey) => {
+  isLoadingFromS3.value = true
+  s3LoadingProgress.value = { completed: 0, total: 0, current: 'Migrating from old system…' }
+  try {
+    const res = await callBackend('get_s3_meta', { key: metaKey })
+    if (!res || !res.found) {
+      frappe.show_alert({ message: 'Old metadata not found; creating new', indicator: 'orange' })
+      scaffoldAndNotify()
+      return
+    }
+    const metadata = res.metadata || {}
+    resetFiles()
+
+    const LEGACY_ROLES = ['icon', 'small', 'medium', 'large']
+    // Dedupe by (role, order, filename); combine SKUs + sites of each referencing product.
+    const byKey = {}
+    const addImage = (role, order, filename, skus, sites) => {
+      if (!filename) return
+      const fn = normalizeFilename(filename)
+      const key = `${role}|${order}|${fn}`
+      if (!byKey[key]) byKey[key] = { role, order, filename: fn, skus: new Set(), sites: new Set() }
+      skus.forEach(s => s && byKey[key].skus.add(s))
+      sites.forEach(s => s && byKey[key].sites.add(s))
+    }
+
+    if (Array.isArray(metadata.products)) {
+      metadata.products.forEach(product => {
+        const skus = Array.isArray(product.productsku) ? product.productsku : [product.productsku].filter(Boolean)
+        const sites = product.sites || []
+        ;(product.images || []).forEach(imageSet => {
+          LEGACY_ROLES.forEach(role => {
+            if (imageSet[role]) addImage(role, imageSet.order || 0, String(imageSet[role]).split('/').pop(), skus, sites)
+          })
+        })
+      })
+    } else if (metadata.products && typeof metadata.products === 'object') {
+      Object.values(metadata.products).forEach(productData => {
+        const skus = productData.skus || []
+        const sites = productData.sites || []
+        Object.entries(productData.images || {}).forEach(([role, imgs]) => {
+          ;(imgs || []).forEach(info => addImage(role, info.order || 0, info.filename, skus, sites))
+        })
+      })
+    }
+
+    // Resolve SKUs → item codes (legacy JSON only carries SKUs).
+    const allSkus = [...new Set(Object.values(byKey).flatMap(v => [...v.skus]))]
+    let itemBySku = {}
+    if (allSkus.length) {
+      try {
+        itemBySku = (await callBackend('resolve_item_codes', { skus: JSON.stringify(allSkus) })) || {}
+      } catch (e) {
+        console.error('Failed to resolve item codes:', e)
+      }
+    }
+
+    // Keep only images that belong to this template's variants.
+    const allowedSku = new Set(templateVariants.value.map(v => v.sku))
+    const allImages = Object.values(byKey).map(v => {
+      const skus = [...v.skus].filter(s => allowedSku.has(s))
+      return {
+        role: v.role,
+        imageInfo: { filename: v.filename, order: v.order },
+        skus,
+        skuItems: skus.map(s => ({ item_code: itemBySku[s] || null, sku: s })),
+        sites: [...v.sites].filter(s => siteNames.value.includes(s))
+      }
+    }).filter(im => im.skus.length)
+
+    await loadAllImages(allImages)
+    frappe.show_alert({ message: 'Migrated data from the old system. Review and Upload to Save', indicator: 'green' })
+  } catch (e) {
+    console.error('Migration failed:', e)
+    frappe.show_alert({ message: 'Migration failed', indicator: 'red' })
+  } finally {
+    isLoadingFromS3.value = false
+    s3LoadingProgress.value = { completed: 0, total: 0, current: '' }
   }
 }
 

--- a/metactical/public/js/components/s3_uploader/FileUploader.vue
+++ b/metactical/public/js/components/s3_uploader/FileUploader.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-4 space-y-6">
     <div class="flex items-center justify-between">
-      <h2 class="text-2xl font-bold">S3-SB-UploadManager</h2>
+      <h2 class="text-2xl font-bold">S3 SB Upload Manager</h2>
       
       <div class="flex items-center gap-3">
         <!-- Settings button -->
@@ -17,30 +17,8 @@
           Settings
         </button>
 
-        <!-- Load from S3 (loads images/metadata from a saved record) -->
-        <button
-          v-if="isS3Configured"
-          @click="showLoadFromS3Modal = true"
-          :disabled="isLoadingFromS3"
-          class="btn btn-default btn-sm flex items-center gap-2"
-          title="Load from S3"
-        >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 21H7a2 2 0 01-2-2V5a2 2 0 012-2h6l2 2h6a2 2 0 012 2v7"/>
-          </svg>
-          {{ isLoadingFromS3 ? 'Loading…' : 'Load from S3' }}
-        </button>
-
         <!-- Control buttons (only shown when images are selected) -->
         <div v-if="files.length" class="flex gap-3">
-          <button
-            v-if="files.length"
-            @click="exportData"
-            :disabled="!allFilesValid || !productValid"
-            class="btn btn-default btn-sm"
-          >
-            Export JSON
-          </button>
           <button
             @click="startUpload"
             :disabled="!canUpload || isUploading"
@@ -76,7 +54,10 @@
           </label>
           <div ref="templateRef"></div>
           <p class="text-xs mt-1" :class="templateItem ? 'text-green-700' : ''">
-            <template v-if="templateItem">
+            <template v-if="isLoadingFromS3">
+              Loading existing record…
+            </template>
+            <template v-else-if="templateItem">
               {{ templateVariants.length }} variant{{ templateVariants.length === 1 ? '' : 's' }} —
               every variant must have all 4 size images.
             </template>
@@ -641,87 +622,6 @@
       </div>
     </div>
 
-    <!-- Load from S3 Modal -->
-    <div v-if="showLoadFromS3Modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4" style="z-index: 9999;" @click="showLoadFromS3Modal = false">
-      <div class="bg-gray-50 rounded-2xl shadow-2xl max-w-lg w-full max-h-[90vh] overflow-y-auto transform transition-all duration-300 scale-100" @click.stop>
-        <!-- Header -->
-        <div class="flex items-center justify-between p-6 border-b border-gray-200 bg-gray-50 rounded-t-2xl">
-          <div class="flex items-center gap-3">
-            <div class="w-10 h-10 bg-gray-50 rounded-xl flex items-center justify-center shadow-lg">
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 21H7a2 2 0 01-2-2V5a2 2 0 012-2h6l2 2h6a2 2 0 012 2v7"/>
-              </svg>
-            </div>
-            <div>
-              <h3 class="text-xl font-bold text-gray-800">Load from S3</h3>
-              <p class="text-sm text-gray-600">Load a saved record by its name</p>
-            </div>
-          </div>
-          <button @click="showLoadFromS3Modal = false" class="btn btn-default btn-sm" title="Close">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-            </svg>
-          </button>
-        </div>
-
-        <!-- Content -->
-        <div class="p-6 space-y-6">
-          <div class="space-y-2">
-            <label class="block text-sm font-semibold text-gray-700">S3 Product Image Meta Data</label>
-            <div ref="loadRecordRef"></div>
-            <p class="text-xs text-gray-600">Load a saved record; all of its images will be loaded.</p>
-          </div>
-
-          <div class="text-center text-xs text-gray-500">— or —</div>
-
-          <div class="space-y-2">
-            <label class="block text-sm font-semibold text-gray-700">S3 metadata file (images/products/meta/)</label>
-            <select
-              v-model="selectedMeta"
-              :disabled="!!selectedRecord"
-              class="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm disabled:cursor-not-allowed"
-            >
-              <option value="">Select a metadata file…</option>
-              <option v-for="m in s3MetaFiles" :key="m.key" :value="m.key">{{ m.name }}</option>
-            </select>
-            <p class="text-xs text-gray-600">Load a legacy metadata JSON exported by the original uploader.</p>
-          </div>
-
-          <!-- Loading Progress -->
-          <div v-if="s3LoadingProgress.total > 0" class="bg-blue-50 rounded-lg p-4 border border-blue-200">
-            <div class="flex items-center justify-between mb-2">
-              <span class="text-sm font-medium text-blue-900">Loading images from S3</span>
-              <span class="text-sm text-blue-600">{{ s3LoadingProgress.completed }} / {{ s3LoadingProgress.total }}</span>
-            </div>
-            <div class="w-full bg-blue-200 rounded-full h-2">
-              <div
-                class="bg-blue-500 h-2 rounded-full transition-all duration-300"
-                :style="{ width: `${(s3LoadingProgress.completed / s3LoadingProgress.total) * 100}%` }"
-              ></div>
-            </div>
-            <div v-if="s3LoadingProgress.current" class="text-xs text-blue-600 mt-1">
-              {{ s3LoadingProgress.current }}
-            </div>
-          </div>
-        </div>
-
-        <!-- Footer -->
-        <div class="flex items-center justify-between p-6 border-t border-gray-200 bg-gray-50 rounded-b-2xl">
-          <span class="text-sm text-gray-600">{{ isLoadingFromS3 ? 'Loading…' : '' }}</span>
-          <div class="flex items-center gap-3">
-            <button @click="showLoadFromS3Modal = false" class="btn btn-default btn-sm">Close</button>
-            <button
-              @click="selectedRecord ? loadS3Metadata({ key: selectedRecord }) : loadFromS3Meta(selectedMeta)"
-              :disabled="(!selectedRecord && !selectedMeta) || isLoadingFromS3"
-              class="btn btn-primary btn-sm"
-            >
-              {{ isLoadingFromS3 ? 'Loading…' : 'Load' }}
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <!-- Settings Component -->
     <Settings
       :show="showSettings"
@@ -815,11 +715,46 @@ const scaffoldVariantCards = () => {
   files.value.push(...cards)
 }
 
-// Resolve the picked Item to its template + variant set and lock the page to it.
+// Clear the file cards (and upload history) without touching the chosen template.
+const resetFiles = () => {
+  files.value.forEach(file => {
+    if (file.preview) URL.revokeObjectURL(file.preview)
+  })
+  files.value = []
+  uploadComplete.value = false
+  uploadProgress.value = { completed: 0, total: 0 }
+  currentUpload.value = null
+  uploadErrors.value = []
+  uploadedFiles.value = []
+}
+
+// Load every image stored on a saved record (by name) into the editor.
+const loadRecordImages = async (recordName) => {
+  const metadata = await callBackend('get_metadata', { name: recordName })
+  // Restore the override flag so the checkbox reflects the saved record.
+  overrideFullProduct.value = !!metadata.overrideFullProduct
+  const allImages = (metadata.images || []).map(im => {
+    const filename = normalizeFilename(im.path.split('/').pop())
+    const skuItems = im.skuItems || []
+    return {
+      productName: (skuItems[0] && skuItems[0].sku) || '',
+      role: im.role,
+      imageInfo: { filename, order: im.order || 0 },
+      skus: skuItems.map(i => i.sku),
+      skuItems,
+      sites: (im.sites || []).filter(site => siteNames.value.includes(site))
+    }
+  })
+  await loadAllImages(allImages)
+}
+
+// Resolve the picked Item to its template + variant set, then either load the
+// template's existing record (if one exists) or scaffold fresh upload slots.
 const applyTemplateFromItem = async (itemCode) => {
   if (!itemCode) {
     templateItem.value = null
     templateVariants.value = []
+    resetFiles()
     return
   }
   try {
@@ -832,26 +767,31 @@ const applyTemplateFromItem = async (itemCode) => {
     return
   }
 
-  // Discard any stale scaffold cards from a previous template.
-  const hadRealFiles = files.value.some(f => !f.isPlaceholder)
-  files.value = files.value.filter(f => !f.isPlaceholder)
+  // Start clean for the newly chosen template.
+  resetFiles()
 
-  // Drop any already-assigned SKUs that aren't variants of the new template
-  // (applies to real/loaded files that we keep).
-  const allowed = new Set(templateVariants.value.map(v => v.sku))
-  let removed = 0
-  files.value.forEach(file => {
-    const kept = (file.skuItems || []).filter(i => allowed.has(i.sku))
-    if (kept.length !== (file.skuItems || []).length) removed += 1
-    file.skuItems = kept
-    file.skus = kept.filter(i => i.sku).map(i => i.sku).join(', ')
-  })
-  if (removed > 0) {
-    frappe.show_alert({ message: `Cleared incompatible SKUs on ${removed} image${removed > 1 ? 's' : ''}`, indicator: 'orange' })
+  // If a record already exists for this template, load it; otherwise scaffold slots.
+  let existing = null
+  try {
+    existing = await callBackend('find_template_record', { template_item: templateItem.value })
+  } catch (e) {
+    console.error('Failed to look up template record:', e)
   }
 
-  // With no real images yet, scaffold one upload card per variant × role.
-  if (!hadRealFiles && templateVariants.value.length) {
+  if (existing && existing.name) {
+    isLoadingFromS3.value = true
+    s3LoadingProgress.value = { completed: 0, total: 0, current: 'Loading record…' }
+    try {
+      await loadRecordImages(existing.name)
+      frappe.show_alert({ message: `Loaded existing record: ${existing.name}`, indicator: 'green' })
+    } catch (e) {
+      console.error('Failed to load existing record:', e)
+      frappe.show_alert({ message: 'Failed to load the existing record', indicator: 'red' })
+    } finally {
+      isLoadingFromS3.value = false
+      s3LoadingProgress.value = { completed: 0, total: 0, current: '' }
+    }
+  } else if (templateVariants.value.length) {
     scaffoldVariantCards()
     frappe.show_alert({ message: `Created ${templateVariants.value.length * ROLES.length} upload slots (${templateVariants.value.length} variants × 4 sizes)`, indicator: 'blue' })
   }
@@ -859,18 +799,6 @@ const applyTemplateFromItem = async (itemCode) => {
   // Reflect the resolved template back into the picker input.
   if (templateControl && templateItem.value && templateControl.get_value() !== templateItem.value) {
     templateControl.set_value(templateItem.value)
-  }
-}
-
-// After loading images, lock the page to the template of the first resolved item,
-// so a loaded record/JSON is immediately editable under the same template constraint.
-const setTemplateFromLoadedImages = async (allImages) => {
-  for (const im of (allImages || [])) {
-    const withCode = (im.skuItems || []).find(i => i.item_code)
-    if (withCode) {
-      await applyTemplateFromItem(withCode.item_code)
-      return
-    }
   }
 }
 
@@ -882,62 +810,9 @@ const currentUpload = ref(null)
 const uploadErrors = ref([])
 const uploadedFiles = ref([])
 
-// S3 Load state
-const showLoadFromS3Modal = ref(false)
+// Load state (loading an existing record when its template is selected)
 const isLoadingFromS3 = ref(false)
 const s3LoadingProgress = ref({ completed: 0, total: 0, current: '' })
-
-// Record picker (native Frappe Link to S3 Product Image Meta Data, by doc name)
-const loadRecordRef = ref(null)
-const selectedRecord = ref('')
-let recordControl = null
-
-// Second source: legacy metadata JSON files under images/products/meta/
-const selectedMeta = ref('')
-const s3MetaFiles = ref([])
-
-const loadS3MetaList = async () => {
-  s3MetaFiles.value = []
-  try {
-    s3MetaFiles.value = (await callBackend('list_s3_meta')) || []
-  } catch (error) {
-    console.error('Failed to list S3 metadata files:', error)
-  }
-}
-
-watch(showLoadFromS3Modal, (open) => {
-  if (!open) return
-  selectedRecord.value = ''
-  selectedMeta.value = ''
-  s3LoadingProgress.value = { completed: 0, total: 0, current: '' }
-  loadS3MetaList()
-  nextTick(() => {
-    if (!loadRecordRef.value) return
-    loadRecordRef.value.innerHTML = ''
-    recordControl = frappe.ui.form.make_control({
-      parent: loadRecordRef.value,
-      render_input: true,
-      df: {
-        fieldtype: 'Link',
-        options: 'S3 Product Image Meta Data',
-        label: 'Record',
-        placeholder: 'Search by record name…',
-        get_query: () => ({ filters: { docstatus: 1 } }),
-      },
-    })
-    recordControl.refresh()
-    recordControl.$input.on('change awesomplete-selectcomplete', () => {
-      setTimeout(() => { selectedRecord.value = recordControl.get_value() || '' }, 0)
-    })
-  })
-})
-
-// Mutual exclusion: pick a record OR a legacy metadata file, not both.
-watch(selectedMeta, (val) => {
-  if (recordControl && recordControl.$input) {
-    recordControl.$input.prop('disabled', !!val)
-  }
-})
 
 // File processing state
 const isProcessingFiles = ref(false)
@@ -1617,25 +1492,6 @@ const getValidationSummary = () => {
   }
 }
 
-// Export functionality for parsed image data
-const exportData = () => {
-  // Export the exact metadata structure: { products: [...] }
-  const metadata = createS3Metadata()
-
-  // Create download link
-  const blob = new Blob([JSON.stringify(metadata, null, 2)], {
-    type: 'application/json'
-  })
-  const url = URL.createObjectURL(blob)
-  const link = document.createElement('a')
-  link.href = url
-  link.download = `s3-upload-data-${new Date().toISOString().split('T')[0]}.json`
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  URL.revokeObjectURL(url)
-}
-
 // Group files by product (base name) for export
 const groupFilesByProduct = () => {
   const groups = {}
@@ -1680,24 +1536,12 @@ const groupFilesByProduct = () => {
 
 // Clear all files
 const clearAllFiles = () => {
-  files.value.forEach(file => {
-    if (file.preview) {
-      URL.revokeObjectURL(file.preview)
-    }
-  })
-  files.value = []
+  resetFiles()
 
   // Clear the locked template + its picker.
   templateItem.value = null
   templateVariants.value = []
   if (templateControl) templateControl.set_value('')
-
-  // Clear upload history
-  uploadComplete.value = false
-  uploadProgress.value = { completed: 0, total: 0 }
-  currentUpload.value = null
-  uploadErrors.value = []
-  uploadedFiles.value = []
 }
 
 // Get role distribution for export
@@ -1984,47 +1828,6 @@ const startUpload = async () => {
   }
 }
 
-// S3 Load functionality — load every image stored on the selected record.
-const loadS3Metadata = async (metaFile) => {
-  if (!isS3Configured.value) return
-
-  isLoadingFromS3.value = true
-  s3LoadingProgress.value = { completed: 0, total: 0, current: 'Loading metadata...' }
-  
-  try {
-    // Load EVERY image stored on this record (by doc name), straight from its
-    // images child table. Each entry already carries its SKUs and sites.
-    const metadata = await callBackend('get_metadata', { name: metaFile.key })
-
-    // Clear existing files
-    clearAllFiles()
-
-    const allImages = (metadata.images || []).map(im => {
-      const filename = normalizeFilename(im.path.split('/').pop())
-      const skuItems = im.skuItems || []
-      return {
-        productName: (skuItems[0] && skuItems[0].sku) || '',
-        role: im.role,
-        imageInfo: { filename, order: im.order || 0 },
-        skus: skuItems.map(i => i.sku),
-        skuItems,
-        sites: (im.sites || []).filter(site => siteNames.value.includes(site))
-      }
-    })
-
-    await loadAllImages(allImages)
-    await setTemplateFromLoadedImages(allImages)
-
-    // Close modal
-    showLoadFromS3Modal.value = false
-    s3LoadingProgress.value = { completed: 0, total: 0, current: '' }
-  } catch (error) {
-    console.error('Failed to load metadata:', error)
-  } finally {
-    isLoadingFromS3.value = false
-  }
-}
-
 // Shared: fetch each loaded image (via the backend) and add file objects to the editor.
 const loadAllImages = async (allImages) => {
   s3LoadingProgress.value.total = allImages.length
@@ -2138,99 +1941,6 @@ const loadAllImages = async (allImages) => {
   }
 
   autoSortFiles()
-}
-
-// Load a legacy metadata JSON file from images/products/meta/ (original s3uploader flow).
-const loadFromS3Meta = async (metaKey) => {
-  if (!metaKey || !isS3Configured.value) return
-
-  isLoadingFromS3.value = true
-  s3LoadingProgress.value = { completed: 0, total: 0, current: 'Loading metadata…' }
-
-  try {
-    const res = await callBackend('get_s3_meta', { key: metaKey })
-    if (!res || !res.found) {
-      frappe.show_alert({ message: 'Metadata file not found in S3', indicator: 'red' })
-      return
-    }
-
-    const metadata = res.metadata || {}
-    clearAllFiles()
-
-    const ROLES = ['icon', 'small', 'medium', 'large']
-
-    // Dedupe images by (role, order, filename); combine the SKUs and sites of every
-    // product that references the same physical image (the JSON lists one image file
-    // under several products since it's named by the first SKU).
-    const byKey = {}
-    const addImage = (role, order, filename, skus, sites) => {
-      if (!filename) return
-      const fn = normalizeFilename(filename)
-      const key = `${role}|${order}|${fn}`
-      if (!byKey[key]) byKey[key] = { role, order, filename: fn, skus: new Set(), sites: new Set() }
-      skus.forEach(s => s && byKey[key].skus.add(s))
-      sites.forEach(s => s && byKey[key].sites.add(s))
-    }
-
-    if (Array.isArray(metadata.products)) {
-      metadata.products.forEach(product => {
-        const skus = Array.isArray(product.productsku)
-          ? product.productsku
-          : [product.productsku].filter(Boolean)
-        const sites = product.sites || []
-        ;(product.images || []).forEach(imageSet => {
-          ROLES.forEach(role => {
-            if (imageSet[role]) {
-              addImage(role, imageSet.order || 0, String(imageSet[role]).split('/').pop(), skus, sites)
-            }
-          })
-        })
-      })
-    } else if (metadata.products && typeof metadata.products === 'object') {
-      // Old object-based structure (backward compatibility)
-      Object.entries(metadata.products).forEach(([, productData]) => {
-        const skus = productData.skus || []
-        const sites = productData.sites || []
-        Object.entries(productData.images || {}).forEach(([role, imgs]) => {
-          ;(imgs || []).forEach(imageInfo => {
-            addImage(role, imageInfo.order || 0, imageInfo.filename, skus, sites)
-          })
-        })
-      })
-    }
-
-    // Resolve item codes for all the SKUs (the JSON only carries SKUs).
-    const allSkus = [...new Set(Object.values(byKey).flatMap(v => [...v.skus]))]
-    let itemBySku = {}
-    if (allSkus.length) {
-      try {
-        itemBySku = (await callBackend('resolve_item_codes', { skus: JSON.stringify(allSkus) })) || {}
-      } catch (e) {
-        console.error('Failed to resolve item codes:', e)
-      }
-    }
-
-    const allImages = Object.values(byKey).map(v => {
-      const skus = [...v.skus]
-      return {
-        role: v.role,
-        imageInfo: { filename: v.filename, order: v.order },
-        skus,
-        skuItems: skus.map(s => ({ item_code: itemBySku[s] || null, sku: s })),
-        sites: [...v.sites].filter(s => siteNames.value.includes(s))
-      }
-    })
-
-    await loadAllImages(allImages)
-    await setTemplateFromLoadedImages(allImages)
-
-    showLoadFromS3Modal.value = false
-    s3LoadingProgress.value = { completed: 0, total: 0, current: '' }
-  } catch (error) {
-    console.error('Failed to load S3 metadata file:', error)
-  } finally {
-    isLoadingFromS3.value = false
-  }
 }
 
 // Function to mark a file as modified


### PR DESCRIPTION
Builds on the template-driven S3 uploader with three improvements to how product-image records are stored, brought in from the old system, and structured by image order.

### Template-keyed records + activity log 

- The S3 Product Image Meta Data doctype is now non-submittable and upserts by Product Template — uploading for a template that already has a record updates it in place instead of creating a duplicate (removed amended_from/docstatus filters accordingly).
- Records are named after the product template (e.g. GOL2144-01) instead of a random hash.
- Every save writes a human-readable activity entry to the timeline, spelling out exactly what changed — item codes added/removed, per-image website changes, image add/remove/replace with role + order, and Override Full Product toggles.

### Migrate from the old S3 system

- When a template has no new-system record, the page checks the old S3 system before scaffolding and offers a popup: Migrate the legacy data or Create new.
- find_legacy_meta locates the old …_metadata.json efficiently via SKU-prefixed LIST + content confirm (no full-folder scan), so it stays sub-second on buckets with very large meta/ folders.
- Removed the old standalone Load from S3 button/modal — loading is now driven by template selection (load existing record · else offer migrate · else create new).

### Per-order image sets

- Added an Image Orders panel with Order 0–10 checkboxes. Checking an order adds icon/small/medium/large slots for every variant at that order; unchecking removes them. Existing orders are auto-checked.
- Also removed the now-unused Export JSON button.
- No destructive S3 operations: unchecking/removing an order drops it from the record only; image objects remain in the bucket.