### PR TITLE
feat: expose s3_product_payload for the webhook to embed product JSON inline

### DIFF
--- a/metactical/hooks.py
+++ b/metactical/hooks.py
@@ -1512,6 +1512,7 @@ jinja = {
 		"metactical.barcode_generator.get_qr_for_print_format",
 		"metactical.custom_scripts.utils.metactical_utils.custom_parse_json",
 		"metactical.custom_scripts.utils.metactical_utils.get_refund_details_for_print",
+		"metactical.metactical.page.s3_uploader.s3_uploader.s3_product_payload",
 	]
 }
 

--- a/metactical/metactical/page/s3_uploader/s3_uploader.py
+++ b/metactical/metactical/page/s3_uploader/s3_uploader.py
@@ -514,6 +514,19 @@ def build_export_json(names=None):
 	return {"products": products}
 
 
+def s3_product_payload(name):
+	"""JSON string of a record's products ({"products": [...]}), for the RabbitMQ webhook.
+
+	Exposed to Jinja via hooks (`jinja.methods`) so the webhook body can embed the metadata
+	inline — the webhook renders `doc` as a plain dict, so a controller method can't be used.
+
+	Uses plain `json.dumps` (not `frappe.as_json`, which sorts keys) so the output matches the
+	"Download JSON" button byte-for-byte in key order.
+	"""
+	doc = frappe.get_doc("S3 Product Image Meta Data", name)
+	return json.dumps({"products": _record_products(doc)})
+
+
 def _strip_data_url(content):
 	"""Accept either a bare base64 string or a `data:<type>;base64,<data>` URL."""
 	if content and content.startswith("data:") and "," in content:


### PR DESCRIPTION
Adds a Jinja-callable helper so the S3 Product Image Meta Data webhook can send the product metadata JSON inline in its request body.