### PR TITLE
feat: migrate Rocket.Chat upload to rooms.media API and fix PR warehouse notification

### DIFF
--- a/metactical/custom_scripts/purchase_receipt/purchase_receipt.py
+++ b/metactical/custom_scripts/purchase_receipt/purchase_receipt.py
@@ -50,9 +50,16 @@ class CustomPurchaseReceipt(PurchaseReceipt):
 		
 def post_rc_message(doc):
 	if not doc.is_return and doc.company == "International Camouflage Ltd":
-		warehouse = frappe.get_doc("Purchase Order", doc.purchase_order).set_warehouse
-  
-		if warehouse == "W01-WHS-Active Stock - ICL":
+		active_warehouse = "W01-WHS-Active Stock - ICL"
+		po = frappe.get_doc("Purchase Order", doc.purchase_order)
+
+		# Some POs don't have set_warehouse set on the header, so fall back to
+		# checking each item's Target Warehouse.
+		is_active = po.set_warehouse == active_warehouse
+		if not po.set_warehouse:
+			is_active = any(item.warehouse == active_warehouse for item in po.items)
+
+		if is_active:
 			frappe.enqueue(
 				send_pdf_to_rocket_chat,
 				name=doc.name

--- a/metactical/custom_scripts/utils/metactical_utils.py
+++ b/metactical/custom_scripts/utils/metactical_utils.py
@@ -62,7 +62,9 @@ def post_to_rocket_chat(doc, msg, failed=False, rmq=False, pos=False, attachment
 				'X-User-Id': rocket_chat_settings.user_id
 			}
 			base_url = rocket_chat_settings.url
-			upload_url = f"{base_url}/api/v1/rooms.upload/{rocket_chat_settings.pr_room_id}"
+			rid = rocket_chat_settings.pr_room_id
+
+			upload_url = f"{base_url}/api/v1/rooms.media/{rid}"
 
 			files = {
 				'file': (filename, attachment, 'application/pdf'),
@@ -73,10 +75,19 @@ def post_to_rocket_chat(doc, msg, failed=False, rmq=False, pos=False, attachment
 				headers=headers,
 				files=files
 			)
-			if response.status_code == 200:
-				pass
+			if response.status_code != 200:
+				frappe.log_error(title='Rocket Chat Error', message=response.text)
 			else:
-				frappe.log_error(title='Rocket Chat Error', message=response.json())
+				file_id = response.json().get('file', {}).get('_id')
+				confirm_url = f"{base_url}/api/v1/rooms.mediaConfirm/{rid}/{file_id}"
+				confirm_headers = {**headers, 'Content-type': 'application/json'}
+				confirm_response = requests.post(
+					confirm_url,
+					headers=confirm_headers,
+					data=json.dumps({})
+				)
+				if confirm_response.status_code != 200:
+					frappe.log_error(title='Rocket Chat Error', message=confirm_response.text)
 		else:
 			channel_name = rocket_chat_settings.channel_name if not pos else rocket_chat_settings.pos_failed_invoices
       


### PR DESCRIPTION
## Summary
Updates the Rocket.Chat integration for the Rocket.Chat v8+ server upgrade and improves Purchase Receipt channel notifications.

## Changes

### `metactical_utils.py` — `post_to_rocket_chat`
- Migrate file-attachment uploads from the removed `rooms.upload/:rid` endpoint to the new two-step `rooms.media/:rid` + `rooms.mediaConfirm/:rid/:fileId` flow (required as of Rocket.Chat v8.0.0).
- Log `response.text` instead of `response.json()` on non-200 responses, so a non-JSON error body no longer raises a secondary `JSONDecodeError` and the actual server response is captured in the error log.

### `purchase_receipt.py` — `post_rc_message`
- Some Purchase Orders don't have `set_warehouse` set on the header. Fall back to checking each PO item's Target Warehouse, so the channel is still notified when an item's target's W01-WHS-Active Stock - ICL`.

## Notes
- `chat.postMessage` is unchanged (endpoint still valid).
- Auth headers (`X-Auth-Token` / `X-User-Id`) are unchanged.
