### PR TITLE
Add brand-based SB Tag matching

### DIFF
--- a/metactical/custom_scripts/item/item.py
+++ b/metactical/custom_scripts/item/item.py
@@ -360,7 +360,17 @@ class CustomItem(Item):
                 if row.item_group
             }
 
-            if self.item_group not in tag_item_groups:
+            tag_brands = {
+                row.brand
+                for row in tag_doc.nat_brands or []
+                if row.brand
+            }
+
+            # Map the tag if the item matches on item group OR on brand
+            matches_item_group = self.item_group in tag_item_groups
+            matches_brand = self.brand in tag_brands
+
+            if not (matches_item_group or matches_brand):
                 continue
 
             if not tag_specs.issubset(item_specs):

--- a/metactical/metactical/doctype/brands_list/brands_list.json
+++ b/metactical/metactical/doctype/brands_list/brands_list.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-07-03 05:52:46.469674",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "item_group"
+ ],
+ "fields": [
+  {
+   "fieldname": "item_group",
+   "fieldtype": "Link",
+   "label": "Brand",
+   "options": "Brand"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-07-03 05:52:56.515262",
+ "modified_by": "Administrator",
+ "module": "Metactical",
+ "name": "Brands List",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/metactical/metactical/doctype/brands_list/brands_list.json
+++ b/metactical/metactical/doctype/brands_list/brands_list.json
@@ -7,11 +7,11 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "item_group"
+  "brand"
  ],
  "fields": [
   {
-   "fieldname": "item_group",
+   "fieldname": "brand",
    "fieldtype": "Link",
    "label": "Brand",
    "options": "Brand"
@@ -20,7 +20,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-07-03 05:52:56.515262",
+ "modified": "2026-07-03 06:08:23.310437",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Brands List",

--- a/metactical/metactical/doctype/brands_list/brands_list.py
+++ b/metactical/metactical/doctype/brands_list/brands_list.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Storebuilder Commerce Inc and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BrandsList(Document):
+	pass

--- a/metactical/metactical/doctype/sb_tag/sb_tag.json
+++ b/metactical/metactical/doctype/sb_tag/sb_tag.json
@@ -13,6 +13,8 @@
   "neb_website_specifications",
   "section_break_mzif",
   "nat_item_groups",
+  "column_break_bdtu",
+  "nat_brands",
   "section_break_sbxf",
   "description"
  ],
@@ -47,7 +49,7 @@
    "columns": 2,
    "fieldname": "nat_item_groups",
    "fieldtype": "Table MultiSelect",
-   "label": "Item Group",
+   "label": "Item Groups",
    "options": "Item Groups List"
   },
   {
@@ -55,12 +57,24 @@
    "fieldname": "published",
    "fieldtype": "Check",
    "label": "Published"
+  },
+  {
+   "fieldname": "column_break_bdtu",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_bulk_edit": 1,
+   "columns": 2,
+   "fieldname": "nat_brands",
+   "fieldtype": "Table MultiSelect",
+   "label": "Brands",
+   "options": "Brands List"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-20 13:13:39.047867",
+ "modified": "2026-07-03 05:54:14.181200",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "SB Tag",


### PR DESCRIPTION
Extends SB Tag auto-assignment so tags can map to items by **brand**, in addition to the existing item-group matching.