### PR TITLE
feat: update Restock Subscription Log to use after_insert for email log creation and adjust related JSON fields

### DIFF
--- a/metactical/custom_scripts/utils/restock_notification_api.py
+++ b/metactical/custom_scripts/utils/restock_notification_api.py
@@ -24,7 +24,6 @@ def create_rmq_log(parsedContent):
 		})
 
 		rmq_log.insert()
-		rmq_log.submit()
 		frappe.db.commit()
 
 	except Exception as e:

--- a/metactical/metactical/doctype/restock_email_log/restock_email_log.json
+++ b/metactical/metactical/doctype/restock_email_log/restock_email_log.json
@@ -101,7 +101,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-09 11:09:29.521385",
+ "modified": "2026-07-09 13:47:57.846660",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Restock Email Log",

--- a/metactical/metactical/doctype/restock_subscription_log/restock_subscription_log.json
+++ b/metactical/metactical/doctype/restock_subscription_log/restock_subscription_log.json
@@ -7,7 +7,6 @@
  "field_order": [
   "section_break_0gxe",
   "column_break_ytcq",
-  "amended_from",
   "customer_email",
   "customer_name",
   "lead_source",
@@ -24,16 +23,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "amended_from",
-   "fieldtype": "Link",
-   "label": "Amended From",
-   "no_copy": 1,
-   "options": "Restock Subscription Log",
-   "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
-  },
-  {
    "fieldname": "column_break_ytcq",
    "fieldtype": "Column Break",
    "options": "Lead"
@@ -43,7 +32,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Customer Email"
+   "label": "Customer Email",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_ksmy",
@@ -54,7 +44,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Lead Source"
+   "label": "Lead Source",
+   "read_only": 1
   },
   {
    "default": "Now",
@@ -62,7 +53,8 @@
    "fieldtype": "Datetime",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Received At"
+   "label": "Received At",
+   "read_only": 1
   },
   {
    "fieldname": "section_break_cjsb",
@@ -72,6 +64,7 @@
    "fieldname": "payload",
    "fieldtype": "Code",
    "label": "Payload",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -79,24 +72,26 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Retail SKU"
+   "label": "Retail SKU",
+   "read_only": 1
   },
   {
    "fieldname": "item_price",
    "fieldtype": "Data",
-   "label": "Item Price"
+   "label": "Item Price",
+   "read_only": 1
   },
   {
    "fieldname": "customer_name",
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Customer Name"
+   "label": "Customer Name",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
- "is_submittable": 1,
  "links": [
   {
    "group": "Notifications",
@@ -104,7 +99,7 @@
    "link_fieldname": "restock_subscription_log"
   }
  ],
- "modified": "2026-06-26 08:11:35.843116",
+ "modified": "2026-07-09 13:08:49.536454",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "Restock Subscription Log",
@@ -120,7 +115,6 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
-   "submit": 1,
    "write": 1
   }
  ],

--- a/metactical/metactical/doctype/restock_subscription_log/restock_subscription_log.py
+++ b/metactical/metactical/doctype/restock_subscription_log/restock_subscription_log.py
@@ -6,6 +6,6 @@ from frappe.model.document import Document
 from metactical.custom_scripts.utils.restock_notification import create_email_log
 
 class RestockSubscriptionLog(Document):
-	def on_submit(self):
-		"""On submit, create a Restock Email Log for this subscription (if one doesn't already exist)."""
+	def after_insert(self):
+		"""On insert, create a Restock Email Log for this subscription (if one doesn't already exist)."""
 		create_email_log(self)


### PR DESCRIPTION
Remove the sumitable from the Restock Subscription Log
And update from on_submit to after_insert to create the Restock Email Log