### PR TITLE
feat: improve email log handling, USAePay refund voiding, and Edmonds MR warehouse assignment

### DIFF
--- a/metactical/custom_scripts/payment_entry/payment_entry.js
+++ b/metactical/custom_scripts/payment_entry/payment_entry.js
@@ -232,7 +232,6 @@ var refund_payment_button = function (
             },
             callback: function (r) {
                 if (r.message) {
-                    console.log("can be refunded");
                     frm.add_custom_button(
                         __("Request Refund"),
                         function () {

--- a/metactical/custom_scripts/payment_entry/payment_entry.py
+++ b/metactical/custom_scripts/payment_entry/payment_entry.py
@@ -375,6 +375,11 @@ def check_if_payment_can_be_refunded(doc, ref, making_refund=False):
 			sales_order = item.sales_order
 			break
 	
+	if not making_refund:
+		existing_refund_doc = frappe.db.get_value("USAePay Refund", {"payment_entry": doc.name}, ["name", "status"])
+		if existing_refund_doc:
+			return False, "", ""
+
 	if sales_invoice.is_return and sales_order and doc.payment_type == "Pay":
 		return True, sales_order, sales_invoice
 	

--- a/metactical/custom_scripts/utils/restock_notification.py
+++ b/metactical/custom_scripts/utils/restock_notification.py
@@ -19,10 +19,9 @@ def create_email_log(sub):
 	# Resolve the actual Item from the retail SKU suffix on the subscription.
 	item_code = get_item_code_from_retail_sku(sub.retail_sku)
 
-	# Auto-send OFF (not checked) -> Pending. Auto-send ON -> Sent.
-	# delivery_status stays blank; the mail service fills it in.
-	status = STATUS_SENT if settings.send_email_automatically else STATUS_PENDING
-
+	# Created as Pending. If auto-send is on we send it right away through the same
+	# path as the manual "Send Email" button, which flips it to Sent and stores the
+	# Message-Id. delivery_status stays blank; the mail service fills it in.
 	log = frappe.get_doc({
 		"doctype": "Restock Email Log",
 		"restock_subscription_log": sub.name,
@@ -33,9 +32,20 @@ def create_email_log(sub):
 		"lead_source": sub.lead_source,
 		"price": sub.item_price,
 		"sent_at": now_datetime(),
-		"status": status,
+		"status": STATUS_PENDING,
 	})
 	log.insert(ignore_permissions=True)
+
+	if settings.send_email_automatically:
+
+		try:
+			send_email(log.name)
+		except Exception:
+			frappe.log_error(
+				title="Restock Notification: auto-send failed",
+				message=frappe.get_traceback(),
+			)
+
 	return log.name
 
 

--- a/metactical/metactical/doctype/usaepay_refund/usaepay_refund.js
+++ b/metactical/metactical/doctype/usaepay_refund/usaepay_refund.js
@@ -9,13 +9,39 @@ frappe.ui.form.on("USAePay Refund", {
             }[frm.doc.status], "status-indicator");
 
         if (frm.doc.docstatus === 0) {
-            frm.page.clear_primary_action();
+            // frm.page.clear_primary_action();
 
             frm.add_custom_button(__('Approve'), () => {
                 frappe.confirm(
                     'Are you sure you want to approve this refund?',
                     () => {
                         frm.save('Submit');
+                    },
+                    () => {
+                        // User cancelled the action
+                    }
+                );
+            });
+
+            frm.add_custom_button(__('Void'), () => {
+                frappe.confirm(
+                    'Are you sure you want to void the original payment?',
+                    () => {
+                        frappe.call({
+                            method: 'metactical.metactical.doctype.usaepay_refund.usaepay_refund.void_useapay_payment',
+                            freeze: true,
+                            freeze_message: __('Voiding the original payment...'),
+                            args: {
+                                refund_name: frm.doc.name
+                            },
+                            callback: function (r) {
+                                if (r.status === 'success') {
+                                    frappe.msgprint(__('The original payment has been voided successfully.'));
+                                } else {
+                                    frappe.msgprint(__('Failed to void the original payment. '+ (r.message || '')));
+                                }
+                            }
+                        });
                     },
                     () => {
                         // User cancelled the action

--- a/metactical/metactical/doctype/usaepay_refund/usaepay_refund.json
+++ b/metactical/metactical/doctype/usaepay_refund/usaepay_refund.json
@@ -85,8 +85,9 @@
   {
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Status",
-   "options": "\nPending\nRefunded\nRejected"
+   "options": "\nPending\nRefunded\nRejected\nVoided"
   },
   {
    "fieldname": "mode_of_payment",
@@ -109,7 +110,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-09 07:34:09.691826",
+ "modified": "2026-07-13 10:02:25.224276",
  "modified_by": "Administrator",
  "module": "Metactical",
  "name": "USAePay Refund",

--- a/metactical/metactical/doctype/usaepay_refund/usaepay_refund.py
+++ b/metactical/metactical/doctype/usaepay_refund/usaepay_refund.py
@@ -1,10 +1,56 @@
 # Copyright (c) 2026, Storebuilder Commerce Inc and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
-from metactical.custom_scripts.payment_entry.payment_entry import make_refund
+from metactical.custom_scripts.payment_entry.payment_entry import make_refund, void_payment
 
 class USAePayRefund(Document):
 	def on_submit(self):
-		make_refund(self.name, self.payment_entry)
+		if self.status and self.status == "Pending":
+			make_refund(self.name, self.payment_entry)
+  
+@frappe.whitelist()
+def void_useapay_payment(refund_name):
+	try:
+		refund_doc = frappe.get_doc("USAePay Refund", refund_name)
+		if refund_doc.status == "Refunded":
+			frappe.throw("This refund has already been processed.")
+	
+	
+		original_usaepay_transaction_key = frappe.db.get_value("Sales Order", refund_doc.sales_order, "neb_usaepay_transaction_key")
+		if not original_usaepay_transaction_key:
+			frappe.throw("No USAePay transaction key found for the associated Sales Order.")
+	 
+		payment_entry = frappe.get_doc("Payment Entry", {"reference_no": original_usaepay_transaction_key})
+		if payment_entry and payment_entry.paid_amount != refund_doc.amount_to_refund:
+			frappe.throw("The refund amount does not match the original payment amount. Please void the original payment from it's Payment Entry")
+   
+		if not payment_entry:
+			frappe.throw("No Payment Entry found for the associated USAePay transaction key.")
+	
+		void_payment(payment_entry.name)
+		create_comment(payment_entry, refund_doc)
+  
+		refund_doc.status = "Voided"
+		refund_doc.save(ignore_permissions=True)
+		refund_doc.submit()
+
+		frappe.response["message"] = "Payment voided successfully."
+		frappe.response["status"] = "success"
+	except Exception as e:
+		frappe.log_error(title="Error voiding USAePay payment", message=frappe.get_traceback())
+		frappe.response["message"] = f"Error voiding payment: {str(e)}"
+		frappe.response["status"] = "error"
+  
+  
+def create_comment(payment_entry, refund_doc):
+    
+	comment_content = f"Payment voided due to refund request: {refund_doc.name}. Refund amount: {payment_entry.paid_amount}."
+	frappe.get_doc({
+		"doctype": "Comment",
+		"comment_type": "Comment",
+		"reference_doctype": "Payment Entry",
+		"reference_name": payment_entry.name,
+		"content": comment_content
+	}).insert(ignore_permissions=True)

--- a/metactical/metactical/report/sales_report___stores_v4/sales_report___stores_v4.py
+++ b/metactical/metactical/report/sales_report___stores_v4/sales_report___stores_v4.py
@@ -279,10 +279,7 @@ def create_material_request(**args):
 		wh_actual = bin_details.get("actual_qty") or 0.0
 		wh_res = bin_details.get("reserved_qty") or 0.0
 		stock_levels = wh_actual - wh_res
-		if row.pos_profile == "Edmonds Operators":
-			transit_warehouse = "R02-Edm-Active Stock - " + frappe.db.get_value("Company", row.company, "abbr")
-		else:
-			transit_warehouse = get_transit_warehouse(row.warehouse)
+		transit_warehouse = get_transit_warehouse(row.warehouse)
 		
 		if stock_levels > 0 and transit_warehouse != "" and row.qty > 0:
 			item_details = get_item_details(frappe._dict({


### PR DESCRIPTION
This PR includes the following improvements:

- Updated `create_email_log` to:
  - Set the email status to **Pending** when automatic sending fails.

- Updated the USAePay refund flow to:
  - Void the payment when the refund transaction is still **unsettled**.

- Updated Sales Report Material Request creation to:
  - Automatically set the **In Transit Warehouse** for Material Requests destined for the **Edmonds** warehouse.