### PR TITLE
refactor: set in-trasit warehouse for material transfers to Edmonds branch

### DIFF
--- a/metactical/metactical/report/sales_report___stores_v4/sales_report___stores_v4.py
+++ b/metactical/metactical/report/sales_report___stores_v4/sales_report___stores_v4.py
@@ -279,10 +279,7 @@ def create_material_request(**args):
 		wh_actual = bin_details.get("actual_qty") or 0.0
 		wh_res = bin_details.get("reserved_qty") or 0.0
 		stock_levels = wh_actual - wh_res
-		if row.pos_profile == "Edmonds Operators":
-			transit_warehouse = "R02-Edm-Active Stock - " + frappe.db.get_value("Company", row.company, "abbr")
-		else:
-			transit_warehouse = get_transit_warehouse(row.warehouse)
+		transit_warehouse = get_transit_warehouse(row.warehouse)
 		
 		if stock_levels > 0 and transit_warehouse != "" and row.qty > 0:
 			item_details = get_item_details(frappe._dict({


### PR DESCRIPTION
When creating a material request from sales reports - stores v4,  the active warehouse from edmonds was being used as in-transit. but now, it's changed to use the actual in-transit warehouse.