### PR TITLE
fix: acknowledge rmq message after the message is processed

### DIFF
--- a/metactical/custom_scripts/rabbitmq/rmq_consumer.py
+++ b/metactical/custom_scripts/rabbitmq/rmq_consumer.py
@@ -333,10 +333,10 @@ class RMQConsumer(object):
         
         # Process the message
         message = json.loads(body)
-        self.acknowledge_message(basic_deliver.delivery_tag)
-
         self.process_message(message)
 
+        self.acknowledge_message(basic_deliver.delivery_tag)
+        
     def process_message(self, message):
         # Retrieve the RabbitMQ Mapping doctype
         connect_to_frappe(self.site)


### PR DESCRIPTION
This pull request makes a small but important change to the order in which messages are acknowledged in the `on_message` method of `rmq_consumer.py`. The message is now acknowledged after it has been processed, rather than before.

- Changed the order of operations in `on_message` so that `acknowledge_message` is called after `process_message`, ensuring messages are only acknowledged if processing succeeds.